### PR TITLE
Fixed std::future_error on startup

### DIFF
--- a/trantor/net/EventLoopThread.h
+++ b/trantor/net/EventLoopThread.h
@@ -40,11 +40,11 @@ class EventLoopThread : NonCopyable
     EventLoop *_loop;
     std::string _loopThreadName;
     void loopFuncs();
-    std::thread _thread;
     std::promise<EventLoop *> _promiseForLoopPointer;
     std::promise<int> _promiseForRun;
     std::promise<int> _promiseForLoop;
     std::once_flag _once;
+    std::thread _thread;
 };
 
 }  // namespace trantor


### PR DESCRIPTION
Fixed std::future_error with the message "no valid state" (or similar) being randomly thrown on startup of drogon in EventLoopThread.cc in line 62. This was caused by the separate thread being started before the whole EventLoopThread object was fully constructed. As I seem to be one of the few affected ones, here is my system:
Fedora 29, GCC 8.3.1, Intel Celeron N3450 (quite slow, maybe that's related to the object being constructed too slow).
I started my drogon webserver since this change about 50 times and haven't had a single crash since then, so it's safe to assume that I fixed the problem after many, many hours. If you need, I can post my drogon-code here as well. 