### PR TITLE
SSL_CTX_use_certificate_file() -> SSL_CTX_use_certificate_chain_file()

### DIFF
--- a/trantor/net/ssl/SSLConnection.cc
+++ b/trantor/net/ssl/SSLConnection.cc
@@ -93,9 +93,12 @@ void initServerSSLContext(const std::shared_ptr<SSLContext> &ctx,
                           const std::string &certPath,
                           const std::string &keyPath)
 {
-    auto r = SSL_CTX_use_certificate_file(ctx->get(),
+    /*auto r = SSL_CTX_use_certificate_file(ctx->get(),
                                           certPath.c_str(),
-                                          SSL_FILETYPE_PEM);
+                                          SSL_FILETYPE_PEM);*/
+										  
+	auto r = SSL_CTX_use_certificate_chain_file(ctx->get(),
+												certPath.c_str());
     if (!r)
     {
         LOG_FATAL << strerror(errno);

--- a/trantor/net/ssl/SSLConnection.cc
+++ b/trantor/net/ssl/SSLConnection.cc
@@ -96,9 +96,8 @@ void initServerSSLContext(const std::shared_ptr<SSLContext> &ctx,
     /*auto r = SSL_CTX_use_certificate_file(ctx->get(),
                                           certPath.c_str(),
                                           SSL_FILETYPE_PEM);*/
-										  
-	auto r = SSL_CTX_use_certificate_chain_file(ctx->get(),
-												certPath.c_str());
+
+    auto r = SSL_CTX_use_certificate_chain_file(ctx->get(), certPath.c_str());
     if (!r)
     {
         LOG_FATAL << strerror(errno);
@@ -280,7 +279,7 @@ ssize_t SSLConnection::writeInLoop(const char *buffer, size_t length)
             int sslerr = SSL_get_error(sslPtr_->get(), sendLen);
             if (sslerr != SSL_ERROR_WANT_WRITE && sslerr != SSL_ERROR_WANT_READ)
             {
-                //LOG_ERROR << "ssl write error:" << sslerr;
+                // LOG_ERROR << "ssl write error:" << sslerr;
                 forceClose();
                 return -1;
             }


### PR DESCRIPTION
According to https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_use_certificate_file.html, it is preferred to use SSL_CTX_use_certificate_chain_file() instead.