### PR TITLE
Scope the Func object and check for empty funcs_ queue

### DIFF
--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -285,8 +285,9 @@ void EventLoop::doRunInLoopFuncs()
 {
     callingFuncs_ = true;
     {
-        // the destructor for the Func may itself insert a new entry into the queue
-        while (! funcs_.empty())
+        // the destructor for the Func may itself insert a new entry into the
+        // queue
+        while (!funcs_.empty())
         {
             Func func;
             while (funcs_.dequeue(func))

--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -285,10 +285,14 @@ void EventLoop::doRunInLoopFuncs()
 {
     callingFuncs_ = true;
     {
-        Func func;
-        while (funcs_.dequeue(func))
+        // the destructor for the Func may itself insert a new entry into the queue
+        while (! funcs_.empty())
         {
-            func();
+            Func func;
+            while (funcs_.dequeue(func))
+            {
+                func();
+            }
         }
     }
     callingFuncs_ = false;

--- a/trantor/utils/LockFreeQueue.h
+++ b/trantor/utils/LockFreeQueue.h
@@ -86,6 +86,13 @@ class MpscQueue : public NonCopyable
         return true;
     }
 
+    bool empty()
+    {
+        BufferNode *tail = tail_.load(std::memory_order_relaxed);
+        BufferNode *next = tail->next_.load(std::memory_order_acquire);
+        return next == nullptr;
+    }
+
   private:
     struct BufferNode
     {


### PR DESCRIPTION
Scope the _Func_ object and check for an empty _funcs__ queue after running the queue - the destructor for a _Func_ may itself insert a new entry into the queue.

This occurred to me in drogon while running queries against an sqlite db using transactions. The _funcs__ queue would empty. But when the last _Func_ in a series of queries captuing a transaction object run, the transaction destructor won't get called until _Func_ goes out of scope. When _Func_ goes out of scope, _doRunInLoopFuncs()_ exits and thread execution will wait for _poller__ - so the commit callback queued by the transaction destructor won't get run until upto _kPollTimeMs_ (10s) later. And any callback attached to the transaction-complete callback will be delayed by an equal amount of time.

This may not be the cleanest approach - suggestions are welcome :)