### PR TITLE
Rename the bzero method of the FixedBuffer class to avoid compilation…

### DIFF
--- a/trantor/utils/LogStream.h
+++ b/trantor/utils/LogStream.h
@@ -80,7 +80,7 @@ class FixedBuffer : NonCopyable
     {
         cur_ = data_;
     }
-    void bzero()
+    void zeroBuffer()
     {
         memset(data_, 0, sizeof(data_));
     }


### PR DESCRIPTION
… errors on Android

resolve #118 