### PR TITLE
Make certificare validation comply with RFC2818

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -84,21 +84,30 @@ inline std::string certNameToRegex(const std::string &certName)
     result.reserve(certName.size() + 11);
 
     bool isStar = false;
+    bool isLeadingStar = true;
     for (char ch : certName)
     {
         if (isStar == false)
         {
             if (ch == '*')
                 isStar = true;
+            else if (ch == '.')
+            {
+                result += "\\.";
+                isLeadingStar = false;
+            }
             else
+            {
                 result.push_back(ch);
+                isLeadingStar = false;
+            }
         }
         else
         {
-            if (ch == '.')
+            if (ch == '.' && isLeadingStar)
                 result += "([^.]*\\.|)?";
             else
-                result += std::string("\\*") + ch;
+                result += std::string("[^.]*") + ch;
             isStar = false;
         }
     }


### PR DESCRIPTION
My previous implementation have a few bugs. According to RFC2818

```
Matching is performed using the matching rules specified by
   [RFC2459].  If more than one identity of a given type is present in
   the certificate (e.g., more than one dNSName name, a match in any one
   of the set is considered acceptable.) Names may contain the wildcard
   character * which is considered to match any single domain name
   component or component fragment. E.g., *.a.com matches foo.a.com but
   not bar.foo.a.com. f*.com matches foo.com but not bar.com.
```

1. It won't match `f*o.com` with `foo.com`
2. (An oversight) `foo.com` matches `foozcom` as I forgot to escape the `.`.