### PR TITLE
add isUnspecified() to indicate if parsing failed

### DIFF
--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -81,6 +81,7 @@ InetAddress::InetAddress(uint16_t port, bool loopbackOnly, bool ipv6)
         addr_.sin_addr.s_addr = htonl(ip);
         addr_.sin_port = htons(port);
     }
+    isUnspecified_ = false;
 }
 
 InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)

--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -93,8 +93,7 @@ InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)
         addr6_.sin6_port = htons(port);
         if (::inet_pton(AF_INET6, ip.c_str(), &addr6_.sin6_addr) <= 0)
         {
-            LOG_SYSERR << "Failed to parse IPv6 address \'" << ip << "\'";
-            abort();
+            return;
         }
     }
     else
@@ -104,10 +103,10 @@ InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)
         addr_.sin_port = htons(port);
         if (::inet_pton(AF_INET, ip.c_str(), &addr_.sin_addr) <= 0)
         {
-            LOG_SYSERR << "Failed to parse IPv4 address \'" << ip << "\'";
-            abort();
+            return;
         }
     }
+    isUnspecified_ = false;
 }
 
 std::string InetAddress::toIpPort() const

--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -93,8 +93,8 @@ InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)
         addr6_.sin6_port = htons(port);
         if (::inet_pton(AF_INET6, ip.c_str(), &addr6_.sin6_addr) <= 0)
         {
-            // LOG_SYSERR << "sockets::fromIpPort";
-            // abort();
+            LOG_SYSERR << "Failed to parse IPv6 address \'" << ip << "\'";
+            abort();
         }
     }
     else
@@ -104,8 +104,8 @@ InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)
         addr_.sin_port = htons(port);
         if (::inet_pton(AF_INET, ip.c_str(), &addr_.sin_addr) <= 0)
         {
-            // LOG_SYSERR << "sockets::fromIpPort";
-            // abort();
+            LOG_SYSERR << "Failed to parse IPv4 address \'" << ip << "\'";
+            abort();
         }
     }
 }

--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -200,6 +200,14 @@ class InetAddress
         addr_.sin_port = port;
     }
 
+    /**
+     * @brief Returns if the address is not initalized.
+     */
+    inline bool isUnspecified() const
+    {
+        return isUnspecified_;
+    }
+
   private:
     union
     {
@@ -207,6 +215,7 @@ class InetAddress
         struct sockaddr_in6 addr6_;
     };
     bool isIpV6_{false};
+    bool isUnspecified_{true};
 };
 
 }  // namespace trantor

--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -203,7 +203,7 @@ class InetAddress
     }
 
     /**
-     * @brief Returns if the address is not initalized.
+     * @brief Return true if the address is not initalized.
      */
     inline bool isUnspecified() const
     {

--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -71,7 +71,8 @@ class InetAddress
      *
      * @param addr
      */
-    explicit InetAddress(const struct sockaddr_in &addr) : addr_(addr)
+    explicit InetAddress(const struct sockaddr_in &addr)
+        : addr_(addr), isUnspecified_(false)
     {
     }
 
@@ -82,7 +83,7 @@ class InetAddress
      * @param addr
      */
     explicit InetAddress(const struct sockaddr_in6 &addr)
-        : addr6_(addr), isIpV6_(true)
+        : addr6_(addr), isIpV6_(true), isUnspecified_(false)
     {
     }
 
@@ -163,6 +164,7 @@ class InetAddress
     {
         addr6_ = addr6;
         isIpV6_ = (addr6_.sin6_family == AF_INET6);
+        isUnspecified_ = false;
     }
 
     /**

--- a/trantor/unittests/InetAddressUnittest.cc
+++ b/trantor/unittests/InetAddressUnittest.cc
@@ -11,7 +11,8 @@ TEST(InetAddress, innerIpTest)
     EXPECT_EQ(true, InetAddress("10.0.0.1", 0).isIntranetIp());
     EXPECT_EQ(true, InetAddress("172.31.10.1", 0).isIntranetIp());
     EXPECT_EQ(true, InetAddress("127.0.0.1", 0).isIntranetIp());
-    EXPECT_EQ(false, InetAddress("example.com", 0).isUnspecified());
+    EXPECT_EQ(true, InetAddress("example.com", 0).isUnspecified());
+    EXPECT_EQ(false, InetAddress("127.0.0.2", 0).isUnspecified());
 }
 int main(int argc, char **argv)
 {

--- a/trantor/unittests/InetAddressUnittest.cc
+++ b/trantor/unittests/InetAddressUnittest.cc
@@ -13,6 +13,7 @@ TEST(InetAddress, innerIpTest)
     EXPECT_EQ(true, InetAddress("127.0.0.1", 0).isIntranetIp());
     EXPECT_EQ(true, InetAddress("example.com", 0).isUnspecified());
     EXPECT_EQ(false, InetAddress("127.0.0.2", 0).isUnspecified());
+    EXPECT_EQ(false, InetAddress("0.0.0.0", 0).isUnspecified());
 }
 int main(int argc, char **argv)
 {

--- a/trantor/unittests/InetAddressUnittest.cc
+++ b/trantor/unittests/InetAddressUnittest.cc
@@ -11,6 +11,7 @@ TEST(InetAddress, innerIpTest)
     EXPECT_EQ(true, InetAddress("10.0.0.1", 0).isIntranetIp());
     EXPECT_EQ(true, InetAddress("172.31.10.1", 0).isIntranetIp());
     EXPECT_EQ(true, InetAddress("127.0.0.1", 0).isIntranetIp());
+    EXPECT_EQ(false, InetAddress("example.com", 0).isUnspecified());
 }
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Throws an exception when `InetAddress::InetAddress` failed to initialize. I'll make a PR on Drogon when this is merged. 

Refer to https://github.com/an-tao/drogon/issues/755 for detail