### PR TITLE
fix: Timer'id is not recycled in timerQueue

### DIFF
--- a/trantor/net/inner/TimerQueue.cc
+++ b/trantor/net/inner/TimerQueue.cc
@@ -270,13 +270,8 @@ void TimerQueue::reset(const std::vector<TimerPtr> &expired,
     loop_->assertInLoopThread();
     for (auto const &timerPtr : expired)
     {
-        // if (timerPtr->isRepeat() &&
-        //     timerIdSet_.find(timerPtr->id()) != timerIdSet_.end())
-        // {
-        //     timerPtr->restart(now);
-        //     insert(timerPtr);
-        // }
-        if (timerIdSet_.find(timerPtr->id()) != timerIdSet_.end())
+        auto iter = timerIdSet_.find(timerPtr->id());
+        if (iter != timerIdSet_.end())
         {
             if (timerPtr->isRepeat())
             {
@@ -285,9 +280,7 @@ void TimerQueue::reset(const std::vector<TimerPtr> &expired,
             }
             else
             {
-                // If the timer has been called and not repeat, it should be removed from the set
-                // I guess you forget that 
-                timerIdSet_.erase(timerPtr->id());
+                timerIdSet_.erase(iter);
             }
         }
         

--- a/trantor/net/inner/TimerQueue.cc
+++ b/trantor/net/inner/TimerQueue.cc
@@ -27,7 +27,7 @@
 
 using namespace trantor;
 #ifdef __linux__
-int createTimerfd()
+static int createTimerfd()
 {
     int timerfd = ::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
     if (timerfd < 0)
@@ -37,7 +37,7 @@ int createTimerfd()
     return timerfd;
 }
 
-struct timespec howMuchTimeFromNow(const TimePoint &when)
+static struct timespec howMuchTimeFromNow(const TimePoint &when)
 {
     auto microSeconds = std::chrono::duration_cast<std::chrono::microseconds>(
                             when - std::chrono::steady_clock::now())
@@ -51,7 +51,7 @@ struct timespec howMuchTimeFromNow(const TimePoint &when)
     ts.tv_nsec = static_cast<long>((microSeconds % 1000000) * 1000);
     return ts;
 }
-void resetTimerfd(int timerfd, const TimePoint &expiration)
+static void resetTimerfd(int timerfd, const TimePoint &expiration)
 {
     // wake up loop by timerfd_settime()
     struct itimerspec newValue;
@@ -65,7 +65,7 @@ void resetTimerfd(int timerfd, const TimePoint &expiration)
         // LOG_SYSERR << "timerfd_settime()";
     }
 }
-void readTimerfd(int timerfd, const TimePoint &now)
+static void readTimerfd(int timerfd, const TimePoint &now)
 {
     uint64_t howmany;
     ssize_t n = ::read(timerfd, &howmany, sizeof howmany);
@@ -99,7 +99,7 @@ void TimerQueue::handleRead()
     reset(expired, now);
 }
 #else
-int64_t howMuchTimeFromNow(const TimePoint &when)
+static int64_t howMuchTimeFromNow(const TimePoint &when)
 {
     auto microSeconds = std::chrono::duration_cast<std::chrono::microseconds>(
                             when - std::chrono::steady_clock::now())
@@ -270,12 +270,27 @@ void TimerQueue::reset(const std::vector<TimerPtr> &expired,
     loop_->assertInLoopThread();
     for (auto const &timerPtr : expired)
     {
-        if (timerPtr->isRepeat() &&
-            timerIdSet_.find(timerPtr->id()) != timerIdSet_.end())
+        // if (timerPtr->isRepeat() &&
+        //     timerIdSet_.find(timerPtr->id()) != timerIdSet_.end())
+        // {
+        //     timerPtr->restart(now);
+        //     insert(timerPtr);
+        // }
+        if (timerIdSet_.find(timerPtr->id()) != timerIdSet_.end())
         {
-            timerPtr->restart(now);
-            insert(timerPtr);
+            if (timerPtr->isRepeat())
+            {
+                timerPtr->restart(now);
+                insert(timerPtr);
+            }
+            else
+            {
+                // If the timer has been called and not repeat, it should be removed from the set
+                // I guess you forget that 
+                timerIdSet_.erase(timerPtr->id());
+            }
         }
+        
     }
 #ifdef __linux__
     if (!timers_.empty())

--- a/trantor/net/inner/TimerQueue.cc
+++ b/trantor/net/inner/TimerQueue.cc
@@ -283,7 +283,6 @@ void TimerQueue::reset(const std::vector<TimerPtr> &expired,
                 timerIdSet_.erase(iter);
             }
         }
-        
     }
 #ifdef __linux__
     if (!timers_.empty())

--- a/trantor/net/inner/TimerQueue.h
+++ b/trantor/net/inner/TimerQueue.h
@@ -27,7 +27,7 @@ namespace trantor
 class EventLoop;
 class Channel;
 using TimerPtr = std::shared_ptr<Timer>;
-struct comp
+struct TimerPtrComparer
 {
     bool operator()(const TimerPtr &x, const TimerPtr &y) const
     {
@@ -61,7 +61,7 @@ class TimerQueue : NonCopyable
     std::shared_ptr<Channel> timerfdChannelPtr_;
     void handleRead();
 #endif
-    std::priority_queue<TimerPtr, std::vector<TimerPtr>, comp> timers_;
+    std::priority_queue<TimerPtr, std::vector<TimerPtr>, TimerPtrComparer> timers_;
 
     bool callingExpiredTimers_;
     bool insert(const TimerPtr &timePtr);

--- a/trantor/net/inner/TimerQueue.h
+++ b/trantor/net/inner/TimerQueue.h
@@ -61,7 +61,8 @@ class TimerQueue : NonCopyable
     std::shared_ptr<Channel> timerfdChannelPtr_;
     void handleRead();
 #endif
-    std::priority_queue<TimerPtr, std::vector<TimerPtr>, TimerPtrComparer> timers_;
+    std::priority_queue<TimerPtr, std::vector<TimerPtr>, TimerPtrComparer>
+        timers_;
 
     bool callingExpiredTimers_;
     bool insert(const TimerPtr &timePtr);

--- a/trantor/utils/Logger.cc
+++ b/trantor/utils/Logger.cc
@@ -77,8 +77,9 @@ static thread_local uint64_t threadId_{0};
 void Logger::formatTime()
 {
     uint64_t now = static_cast<uint64_t>(date_.secondsSinceEpoch());
-    uint64_t microSec = static_cast<uint64_t>(
-        date_.microSecondsSinceEpoch() - date_.roundSecond().microSecondsSinceEpoch());
+    uint64_t microSec =
+        static_cast<uint64_t>(date_.microSecondsSinceEpoch() -
+                              date_.roundSecond().microSecondsSinceEpoch());
     if (now != lastSecond_)
     {
         lastSecond_ = now;

--- a/trantor/utils/Logger.cc
+++ b/trantor/utils/Logger.cc
@@ -76,11 +76,6 @@ static thread_local uint64_t threadId_{0};
 
 void Logger::formatTime()
 {
-    // uint64_t now = date_.microSecondsSinceEpoch();
-    // uint64_t microSec = now % 1000000;
-    // now = now / 1000000;
-    
-    // reduce magic number
     uint64_t now = static_cast<uint64_t>(date_.secondsSinceEpoch());
     uint64_t microSec = static_cast<uint64_t>(
         date_.microSecondsSinceEpoch() - date_.roundSecond().microSecondsSinceEpoch());

--- a/trantor/utils/Logger.cc
+++ b/trantor/utils/Logger.cc
@@ -76,9 +76,14 @@ static thread_local uint64_t threadId_{0};
 
 void Logger::formatTime()
 {
-    uint64_t now = date_.microSecondsSinceEpoch();
-    uint64_t microSec = now % 1000000;
-    now = now / 1000000;
+    // uint64_t now = date_.microSecondsSinceEpoch();
+    // uint64_t microSec = now % 1000000;
+    // now = now / 1000000;
+    
+    // reduce magic number
+    uint64_t now = static_cast<uint64_t>(date_.secondsSinceEpoch());
+    uint64_t microSec = static_cast<uint64_t>(
+        date_.microSecondsSinceEpoch() - date_.roundSecond().microSecondsSinceEpoch());
     if (now != lastSecond_)
     {
         lastSecond_ = now;


### PR DESCRIPTION
 If the timer has been called and not repeat, it should be removed from the TimerQueue.timerIdSet_