### PR TITLE
Update AsyncFileLogger.cc

### DIFF
--- a/trantor/utils/AsyncFileLogger.cc
+++ b/trantor/utils/AsyncFileLogger.cc
@@ -54,13 +54,7 @@ AsyncFileLogger::~AsyncFileLogger()
         std::lock_guard<std::mutex> guard_(mutex_);
         if (logBufferPtr_->length() > 0)
         {
-            writeBuffers_.push(logBufferPtr_);
-        }
-        if (writeBuffers_.size() > 0)
-        {
-            StringPtr tmpPtr = (StringPtr &&) writeBuffers_.front();
-            writeBuffers_.pop();
-            writeLogToFile(tmpPtr);
+            writeLogToFile(logBufferPtr_);
         }
     }
 }


### PR DESCRIPTION
Since at line no.50 the threadPtr_ already joined, it means that tmpBuffers_ as well as writeBuffers_ are already empty. There's no need to push the current logBufferPtr_ back to writeBuffers_ and pop it out again.