### PR TITLE
add wincrypt.h include for Windows

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -24,6 +24,7 @@
 #else
 #include <WinSock2.h>
 #include <Windows.h>
+#include <wincrypt.h>
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
The following include fixes compilation under Windows 20H2 (19042.928)-x64. I do not know why, but without this include the build fails.