### PR TITLE
Allow OpenSSL recognize SSL_CONF_cmd options

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -209,7 +209,6 @@ class SSLContext
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CERTIFICATE);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
-        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CMDLINE);
         SSL_CONF_CTX_set_ssl_ctx(cctx, ctxPtr_);
         for (const auto &cmd : sslConfCmds)
         {
@@ -233,7 +232,6 @@ class SSLContext
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CERTIFICATE);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
-        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CMDLINE);
         SSL_CONF_CTX_set_ssl_ctx(cctx, ctxPtr_);
         for (const auto &cmd : sslConfCmds)
         {

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -208,8 +208,10 @@ class SSLContext
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SERVER);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CERTIFICATE);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CMDLINE);
         SSL_CONF_CTX_set_ssl_ctx(cctx, ctxPtr_);
-        for (auto cmd : sslConfCmds)
+        for (const auto &cmd : sslConfCmds)
         {
             SSL_CONF_cmd(cctx, cmd.first.data(), cmd.second.data());
         }
@@ -230,8 +232,10 @@ class SSLContext
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SERVER);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CERTIFICATE);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CMDLINE);
         SSL_CONF_CTX_set_ssl_ctx(cctx, ctxPtr_);
-        for (auto cmd : sslConfCmds)
+        for (const auto &cmd : sslConfCmds)
         {
             SSL_CONF_cmd(cctx, cmd.first.data(), cmd.second.data());
         }


### PR DESCRIPTION
OpenSSL requires either SSL_CONF_FLAG_CMDLINE, SSL_CONF_FLAG_FILE, or both be enabled to recognize SSL_CONF_cmd options.

However, I didn't notice that in an-tao/trantor#148, so here is a fix for that.

Sorry for not checking it carefully then.

See https://www.openssl.org/docs/manmaster/man3/SSL_CONF_CTX_set_flags.html and 
https://www.openssl.org/docs/manmaster/man3/SSL_CONF_cmd.html for more detail.