### PR TITLE
Add runOnQuit

### DIFF
--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -274,6 +274,15 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
         return callingFuncs_;
     }
 
+    /**
+     * @brief Run functions when the event loop quits
+     *
+     * @param cb the function to run
+     * @note the function runs on the thread that quits the EventLoop
+     */
+    void runOnQuit(Func &&cb);
+    void runOnQuit(const Func &cb);
+
   private:
     void abortNotInLoopThread();
     void wakeup();
@@ -289,6 +298,7 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
     bool eventHandling_;
     MpscQueue<Func> funcs_;
     std::unique_ptr<TimerQueue> timerQueue_;
+    MpscQueue<Func> funcsOnQuit_;
     bool callingFuncs_{false};
 #ifdef __linux__
     int wakeupFd_;

--- a/trantor/tests/CMakeLists.txt
+++ b/trantor/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(kickoff_test KickoffTest.cc)
 add_executable(dns_test DnsTest.cc)
 add_executable(delayed_ssl_server_test DelayedSSLServerTest.cc)
 add_executable(delayed_ssl_client_test DelayedSSLClientTest.cc)
+add_executable(run_on_quit_test RunOnQuitTest.cc)
 set(targets_list
     ssl_server_test
     ssl_client_test
@@ -38,7 +39,8 @@ set(targets_list
     kickoff_test
     dns_test
     delayed_ssl_server_test
-    delayed_ssl_client_test)
+    delayed_ssl_client_test
+    run_on_quit_test)
 
 set_property(TARGET ${targets_list} PROPERTY CXX_STANDARD 14)
 set_property(TARGET ${targets_list} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/trantor/tests/RunOnQuitTest.cc
+++ b/trantor/tests/RunOnQuitTest.cc
@@ -1,0 +1,27 @@
+#include <trantor/net/EventLoopThread.h>
+#include <iostream>
+#include <atomic>
+#include <future>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+int main()
+{
+    std::atomic<bool> flag(false);
+    {
+        trantor::EventLoopThread thr;
+        thr.getLoop()->runOnQuit([&]() { flag = true; });
+        thr.run();
+        thr.getLoop()->quit();
+    }
+
+    if (flag == false)
+    {
+        std::cerr << "Test failed\n";
+    }
+    else
+    {
+        std::cout << "Success\n";
+    }
+}


### PR DESCRIPTION
Required for https://github.com/an-tao/drogon/pull/890. Adds a `runOnQuit` method to register callbacks that will be called when the event loop quits. Quits the event loop upon destruction. And adds a test.