### PR TITLE
Fix warning C4244 in MSVC (conversion from 'const uint64_t' to 'size_t')

### DIFF
--- a/trantor/utils/Logger.h
+++ b/trantor/utils/Logger.h
@@ -134,7 +134,7 @@ class TRANTOR_EXPORT Logger : public NonCopyable
   protected:
     static void defaultOutputFunction(const char *msg, const uint64_t len)
     {
-        fwrite(msg, 1, len, stdout);
+        fwrite(msg, 1, static_cast<size_t>(len), stdout);
     }
     static void defaultFlushFunction()
     {


### PR DESCRIPTION
Hello! This is a fix for the following C++ warning in MSVC, which sounds like 
`trantor\utils\Logger.h(122): warning C4244: 'argument': conversion from 'const uint64_t' to 'size_t', possible loss of data`
and this patch fixes it. Please apply or fix this in any other way because this warning is annoying 😊