### PR TITLE
Avoid a small memory leak

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -213,6 +213,7 @@ class SSLContext
             SSL_CONF_cmd(cctx, cmd.first.data(), cmd.second.data());
         }
         SSL_CONF_CTX_finish(cctx);
+        SSL_CONF_CTX_free(cctx);
         if (!useOldTLS)
         {
             SSL_CTX_set_min_proto_version(ctxPtr_, TLS1_2_VERSION);
@@ -236,6 +237,7 @@ class SSLContext
             SSL_CONF_cmd(cctx, cmd.first.data(), cmd.second.data());
         }
         SSL_CONF_CTX_finish(cctx);
+        SSL_CONF_CTX_free(cctx);
         if (!useOldTLS)
         {
             SSL_CTX_set_options(ctxPtr_, SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);


### PR DESCRIPTION
`SSL_CONF_CTX_free()` needs to be called after `SSL_CONF_CTX_finish()`
OpenSSL docs: https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_CTX_new.html

I only tested with OpenSSL 1.1.1, but I believe OpenSSL 1.0.x should be the same.