### PR TITLE
cmake: Use GNUInstallDirs to figure out install dirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,14 @@ set(TRANTOR_PATCH_VERSION 1)
 set(TRANTOR_VERSION
     ${TRANTOR_MAJOR_VERSION}.${TRANTOR_MINOR_VERSION}.${TRANTOR_PATCH_VERSION})
 
+include(GNUInstallDirs)
 # Offer the user the choice of overriding the installation directories
-set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
+set(INSTALL_BIN_DIR ${CMAKE_INSTALL_BINDIR} CACHE PATH "Installation directory for binaries")
+set(INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE PATH "Installation directory for libraries")
 set(INSTALL_INCLUDE_DIR
-    include
+    ${CMAKE_INSTALL_INCLUDEDIR}
     CACHE PATH "Installation directory for header files")
-set(DEF_INSTALL_TRANTOR_CMAKE_DIR lib/cmake/Trantor)
+set(DEF_INSTALL_TRANTOR_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/Trantor)
 set(INSTALL_TRANTOR_CMAKE_DIR
     ${DEF_INSTALL_TRANTOR_CMAKE_DIR}
     CACHE PATH "Installation directory for cmake files")


### PR DESCRIPTION
Changes the default values of `INSTALL_*_DIR` and sets an initial value for `INSTALL_BIN_DIR` (was used but empty before).

Some Linux distributions put libraries into `lib`, some into `lib64`, Debian uses `lib/<multiarch-tuple>`. [GNUInstallDirs](https://cmake.org/cmake/help/v3.5/module/GNUInstallDirs.html) detects that and is available in CMake 3.5.