### PR TITLE
Disable setting SSL Configs when using LibreSSL

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -204,7 +204,7 @@ class SSLContext
         ctxPtr_ = SSL_CTX_new(TLS_method());
         if (sslConfCmds.size() != 0)
         {
-            LOF_WARN << "LibreSSL does not support SSL confuration commands";
+            LOF_WARN << "LibreSSL does not support SSL configuration commands";
         }
         if (!useOldTLS)
         {

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -202,9 +202,10 @@ class SSLContext
     {
 #ifdef LIBRESSL_VERSION_NUMBER
         ctxPtr_ = SSL_CTX_new(TLS_method());
-        if(sslConfCmds.size() != 0)
+        if (sslConfCmds.size() != 0)
         {
-            LOG_WARN << "LibreSSL does not support SSL confuration commands";
+            LOG_FATAL << "LibreSSL does not support SSL confuration commands";
+            exit(1);
         }
         if (!useOldTLS)
         {

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -200,7 +200,17 @@ class SSLContext
         bool enableValidtion,
         const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
     {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#ifdef LIBRESSL_VERSION_NUMBER
+        ctxPtr_ = SSL_CTX_new(TLS_method());
+        if(sslConfCmds.size() != 0)
+        {
+            LOG_WARN << "LibreSSL does not support SSL confuration commands";
+        }
+        if (!useOldTLS)
+        {
+            SSL_CTX_set_min_proto_version(ctxPtr_, TLS1_2_VERSION);
+        }
+#elif (OPENSSL_VERSION_NUMBER >= 0x10100000L)
         ctxPtr_ = SSL_CTX_new(TLS_method());
         SSL_CONF_CTX *cctx = SSL_CONF_CTX_new();
         SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SERVER);

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -204,7 +204,7 @@ class SSLContext
         ctxPtr_ = SSL_CTX_new(TLS_method());
         if (sslConfCmds.size() != 0)
         {
-            LOF_WARN << "LibreSSL does not support SSL configuration commands";
+            LOG_WARN << "LibreSSL does not support SSL configuration commands";
         }
         if (!useOldTLS)
         {

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -204,8 +204,7 @@ class SSLContext
         ctxPtr_ = SSL_CTX_new(TLS_method());
         if (sslConfCmds.size() != 0)
         {
-            LOG_FATAL << "LibreSSL does not support SSL confuration commands";
-            exit(1);
+            LOF_WARN << "LibreSSL does not support SSL confuration commands";
         }
         if (!useOldTLS)
         {


### PR DESCRIPTION
LibreSSL (mostly used by OpenBSD) does not support SSL_CONF* which is introduced in #148. This PR disables that support when encountering LibreSSL.

Should this be a warning or a fatal error?