### PR TITLE
Enable checking for revoked certifcate

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -266,6 +266,15 @@ class SSLContext
         if (enableValidtion)
             SSL_CTX_set_default_verify_paths(ctxPtr_);
 #endif
+
+        if(enableValidtion)
+        {
+            X509_STORE *x509_store = SSL_CTX_get_cert_store(ctxPtr_);
+            X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();
+            X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_CRL_CHECK);
+            X509_STORE_set1_param(x509_store, param);
+            X509_VERIFY_PARAM_free(param);
+        }
     }
     ~SSLContext()
     {

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -267,7 +267,7 @@ class SSLContext
             SSL_CTX_set_default_verify_paths(ctxPtr_);
 #endif
 
-        if(enableValidtion)
+        if (enableValidtion)
         {
             X509_STORE *x509_store = SSL_CTX_get_cert_store(ctxPtr_);
             X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();


### PR DESCRIPTION
This PR enables trantor's TCP client to check is the server's certificate is revoked by the CA. This _may_ cause incompatibilities 
if the user supplied their own certificate store and the stores doesn't have a CLR (certificate revoke list). Which should be rare and the solution is to add a CLR themselves.