### PR TITLE
Improve Error handling for certificates/private keys

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -322,13 +322,11 @@ std::shared_ptr<SSLContext> newSSLServerContext(
 {
     auto ctx = newSSLContext(useOldTLS, false, sslConfCmds);
     auto r = SSL_CTX_use_certificate_chain_file(ctx->get(), certPath.c_str());
+    char errbuf[BUFSIZ];
     if (!r)
     {
-#ifndef _MSC_VER
-        LOG_FATAL << strerror(errno);
-#else
-        LOG_FATAL << strerror_tl(errno);
-#endif
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+        LOG_FATAL << errbuf;
         abort();
     }
     r = SSL_CTX_use_PrivateKey_file(ctx->get(),
@@ -336,21 +334,15 @@ std::shared_ptr<SSLContext> newSSLServerContext(
                                     SSL_FILETYPE_PEM);
     if (!r)
     {
-#ifndef _MSC_VER
-        LOG_FATAL << strerror(errno);
-#else
-        LOG_FATAL << strerror_tl(errno);
-#endif
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+        LOG_FATAL << errbuf;
         abort();
     }
     r = SSL_CTX_check_private_key(ctx->get());
     if (!r)
     {
-#ifndef _MSC_VER
-        LOG_FATAL << strerror(errno);
-#else
-        LOG_FATAL << strerror_tl(errno);
-#endif
+        ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
+        LOG_FATAL << errbuf;
         abort();
     }
     return ctx;

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -326,7 +326,7 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     if (!r)
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
-        LOG_FATAL << errbuf;
+        LOG_FATAL << "Reading certificate: " << errbuf;
         abort();
     }
     r = SSL_CTX_use_PrivateKey_file(ctx->get(),
@@ -335,14 +335,14 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     if (!r)
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
-        LOG_FATAL << errbuf;
+        LOG_FATAL << "Reading private key: " << errbuf;
         abort();
     }
     r = SSL_CTX_check_private_key(ctx->get());
     if (!r)
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
-        LOG_FATAL << errbuf;
+        LOG_FATAL << "Checking private key matches certificate: " << errbuf;
         abort();
     }
     return ctx;


### PR DESCRIPTION
Currently the error handling attempts to use errno to print an error, which is mostly useless, because an OpenSSL error parsing the certificate file for example will not set errno. This PR uses the OpenSSL error functions instead to provide a more readable error message, and also includes information about what is actually being processed at the time (i.e. the cert file or the private key etc.)