### PR TITLE
allow RVO in fromDbStringLocal

### DIFF
--- a/trantor/utils/Date.cc
+++ b/trantor/utils/Date.cc
@@ -310,8 +310,7 @@ Date Date::fromDbStringLocal(const std::string &datetime)
             }
         }
     }
-    return std::move(
-        trantor::Date(year, month, day, hour, minute, second, microSecond));
+    return trantor::Date(year, month, day, hour, minute, second, microSecond);
 }
 std::string Date::toCustomedFormattedStringLocal(const std::string &fmtStr,
                                                  bool showMicroseconds) const


### PR DESCRIPTION
The current code returns a rvalue reference, This PR changes it to use RVO as returning rvalue-ref prevents RVO. This is faster on GCC while performance is the same on clang.

(performance on GCC)
![圖片](https://user-images.githubusercontent.com/8792393/142604095-7670c9ec-ee43-4c3b-abb3-30b6227be510.png)
