### PR TITLE
TcpClientImpl support SSL client certificate

### DIFF
--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -231,6 +231,8 @@ void TcpClient::enableSSL(
     (void)validateCert;
     (void)hostname;
     (void)sslConfCmds;
+    (void)certPath;
+    (void)keyPath;
 
     LOG_FATAL << "OpenSSL is not found in your system!";
     abort();

--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -206,11 +206,14 @@ void TcpClient::enableSSL(
     bool useOldTLS,
     bool validateCert,
     std::string hostname,
-    const std::vector<std::pair<std::string, std::string>> &sslConfCmds)
+    const std::vector<std::pair<std::string, std::string>> &sslConfCmds,
+    const std::string &certPath,
+    const std::string &keyPath)
 {
 #ifdef USE_OPENSSL
     /* Create a new OpenSSL context */
-    sslCtxPtr_ = newSSLContext(useOldTLS, validateCert, sslConfCmds);
+    sslCtxPtr_ = newSSLClientContext(
+        useOldTLS, validateCert, certPath, keyPath, sslConfCmds);
     validateCert_ = validateCert;
     if (!hostname.empty())
     {

--- a/trantor/net/TcpClient.h
+++ b/trantor/net/TcpClient.h
@@ -199,6 +199,8 @@ class TRANTOR_EXPORT TcpClient : NonCopyable
      * not used.
      * @param sslConfCmds The commands used to call the SSL_CONF_cmd function in
      * OpenSSL.
+     * @param certPath The path of the certificate file.
+     * @param keyPath The path of the private key file.
      * @note It's well known that TLS 1.0 and 1.1 are not considered secure in
      * 2020. And it's a good practice to only use TLS 1.2 and above.
      */
@@ -206,7 +208,9 @@ class TRANTOR_EXPORT TcpClient : NonCopyable
                    bool validateCert = true,
                    std::string hostname = "",
                    const std::vector<std::pair<std::string, std::string>>
-                       &sslConfCmds = {});
+                       &sslConfCmds = {},
+                   const std::string &certPath = "",
+                   const std::string &keyPath = "");
 
   private:
     /// Not thread safe, but in loop

--- a/trantor/net/inner/TcpConnectionImpl.h
+++ b/trantor/net/inner/TcpConnectionImpl.h
@@ -47,6 +47,13 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     const std::string &keyPath,
     bool useOldTLS,
     const std::vector<std::pair<std::string, std::string>> &sslConfCmds);
+std::shared_ptr<SSLContext> newSSLClientContext(
+    bool useOldTLS,
+    bool validateCert,
+    const std::string &certPath = "",
+    const std::string &keyPath = "",
+    const std::vector<std::pair<std::string, std::string>> &sslConfCmds = {});
+
 // void initServerSSLContext(const std::shared_ptr<SSLContext> &ctx,
 //                           const std::string &certPath,
 //                           const std::string &keyPath);


### PR DESCRIPTION
Adds support for client certificates. Needed for https://github.com/drogonframework/drogon/pull/1090