### PR TITLE
Move EventLoop::runAfter to a template

### DIFF
--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -202,28 +202,6 @@ void EventLoop::abortNotInLoopThread()
                  "thread";
     exit(1);
 }
-void EventLoop::runInLoop(const Func &cb)
-{
-    if (isInLoopThread())
-    {
-        cb();
-    }
-    else
-    {
-        queueInLoop(cb);
-    }
-}
-void EventLoop::runInLoop(Func &&cb)
-{
-    if (isInLoopThread())
-    {
-        cb();
-    }
-    else
-    {
-        queueInLoop(std::move(cb));
-    }
-}
 void EventLoop::queueInLoop(const Func &cb)
 {
     funcs_.enqueue(cb);

--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -122,18 +122,6 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
      * f is executed directly before the method exiting.
      */
     template <typename Functor>
-    inline void runInLoop(const Functor &f)
-    {
-        if (isInLoopThread())
-        {
-            f();
-        }
-        else
-        {
-            queueInLoop(f);
-        }
-    }
-    template <typename Functor>
     inline void runInLoop(Functor &&f)
     {
         if (isInLoopThread())

--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -121,8 +121,30 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
      * @note If the current thread is the thread of the event loop, the function
      * f is executed directly before the method exiting.
      */
-    void runInLoop(const Func &f);
-    void runInLoop(Func &&f);
+    template <typename Functor>
+    inline void runInLoop(const Functor &f)
+    {
+        if (isInLoopThread())
+        {
+            f();
+        }
+        else
+        {
+            queueInLoop(f);
+        }
+    }
+    template <typename Functor>
+    inline void runInLoop(Functor &&f)
+    {
+        if (isInLoopThread())
+        {
+            f();
+        }
+        else
+        {
+            queueInLoop(std::forward<Functor>(f));
+        }
+    }
 
     /**
      * @brief Run the function f in the thread of the event loop.


### PR DESCRIPTION
This PR moves `EventLoop::runAfter` into a template. This is a slight optimization that prevents a heap allocation when runAfter is called on the event thread. The old API forces creation of a std::function object no matter what. 