### PR TITLE
Prevent TcpClient::removeConnection call on deleted TcpClient instance.

### DIFF
--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -184,7 +184,7 @@ void TcpClient::newConnection(int sockfd)
                               std::dynamic_pointer_cast<TcpConnectionImpl>(c)));
             }
         });
-    conn->setCloseCallback(closeCb);
+    conn->setCloseCallback(std::move(closeCb));
     {
         std::lock_guard<std::mutex> lock(mutex_);
         connection_ = conn;

--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -82,25 +82,25 @@ TcpClient::~TcpClient()
     {
         std::lock_guard<std::mutex> lock(mutex_);
         conn = std::dynamic_pointer_cast<TcpConnectionImpl>(connection_);
-    }
-    if (conn)
-    {
-        assert(loop_ == conn->getLoop());
-        // TODO: not 100% safe, if we are in different thread
-        auto loop = loop_;
-        loop_->runInLoop([conn, loop]() {
-            conn->setCloseCallback([loop](const TcpConnectionPtr &connPtr) {
-                loop->queueInLoop([connPtr]() {
-                    static_cast<TcpConnectionImpl *>(connPtr.get())
-                        ->connectDestroyed();
+        if (conn)
+        {
+            assert(loop_ == conn->getLoop());
+            // TODO: not 100% safe, if we are in different thread
+            auto loop = loop_;
+            loop_->runInLoop([conn, loop]() {
+                conn->setCloseCallback([loop](const TcpConnectionPtr &connPtr) {
+                    loop->queueInLoop([connPtr]() {
+                        static_cast<TcpConnectionImpl *>(connPtr.get())
+                            ->connectDestroyed();
+                    });
                 });
             });
-        });
-        conn->forceClose();
-    }
-    else
-    {
-        connector_->stop();
+            conn->forceClose();
+        }
+        else
+        {
+            connector_->stop();
+        }
     }
 }
 
@@ -166,7 +166,23 @@ void TcpClient::newConnection(int sockfd)
     conn->setConnectionCallback(connectionCallback_);
     conn->setRecvMsgCallback(messageCallback_);
     conn->setWriteCompleteCallback(writeCompleteCallback_);
-    conn->setCloseCallback(std::bind(&TcpClient::removeConnection, this, _1));
+
+    std::weak_ptr<TcpClient> weakSelf(shared_from_this());
+    auto closeCb = std::function<void(const TcpConnectionPtr &)>([weakSelf](const TcpConnectionPtr & c) {
+        if ( auto self = weakSelf.lock() )
+        {
+            self->removeConnection(c);
+        }
+        // Else the TcpClient instance has already been destroyed
+        else
+        {
+            LOG_DEBUG << "TcpClient::removeConnection was skipped because TcpClient instanced already freed";
+            c->getLoop()->queueInLoop(
+                std::bind(&TcpConnectionImpl::connectDestroyed,
+                  std::dynamic_pointer_cast<TcpConnectionImpl>(c)));
+        }
+    });
+    conn->setCloseCallback(closeCb);
     {
         std::lock_guard<std::mutex> lock(mutex_);
         connection_ = conn;

--- a/trantor/net/TcpClient.h
+++ b/trantor/net/TcpClient.h
@@ -34,7 +34,8 @@ class SSLContext;
  * @brief This class represents a TCP client.
  *
  */
-class TRANTOR_EXPORT TcpClient : NonCopyable, public std::enable_shared_from_this<TcpClient>
+class TRANTOR_EXPORT TcpClient : NonCopyable,
+                                 public std::enable_shared_from_this<TcpClient>
 {
   public:
     /**

--- a/trantor/net/TcpClient.h
+++ b/trantor/net/TcpClient.h
@@ -34,7 +34,7 @@ class SSLContext;
  * @brief This class represents a TCP client.
  *
  */
-class TRANTOR_EXPORT TcpClient : NonCopyable
+class TRANTOR_EXPORT TcpClient : NonCopyable, public std::enable_shared_from_this<TcpClient>
 {
   public:
     /**


### PR DESCRIPTION
This patch prevents TcpClient::removeConnection from being called if the TcpClient instance has already been destroyed. It's discussed further is Issue #1154.