### PR TITLE
Wait for loop to exit in EventLoop destructor.

### DIFF
--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -113,9 +113,9 @@ void EventLoop::resetAfterFork()
 EventLoop::~EventLoop()
 {
 #ifdef _WIN32
-    DWORD delay = 1;    /* 1 msec */
+    DWORD delay = 1; /* 1 msec */
 #else
-    struct timespec delay = { 0, 1000000 }; /* 1 msec */
+    struct timespec delay = {0, 1000000}; /* 1 msec */
 #endif
 
     quit();
@@ -126,7 +126,7 @@ EventLoop::~EventLoop()
     // If this cannot be guaranteed then one option
     // might be to abort waiting and
     // assert(!looping_) after some delay;
-    while ( looping_ )
+    while (looping_)
     {
 #ifdef _WIN32
         Sleep(delay);

--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -25,6 +25,7 @@
 #include <thread>
 #include <assert.h>
 #ifdef _WIN32
+#include <windows.h>
 #include <io.h>
 #include <synchapi.h>
 using ssize_t = long long;

--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -297,9 +297,9 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
     void abortNotInLoopThread();
     void wakeup();
     void wakeupRead();
-    bool looping_;
+    volatile bool looping_;
     std::thread::id threadId_;
-    bool quit_;
+    volatile bool quit_;
     std::unique_ptr<Poller> poller_;
 
     ChannelList activeChannels_;

--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -28,6 +28,7 @@
 #include <functional>
 #include <chrono>
 #include <limits>
+#include <atomic>
 
 namespace trantor
 {
@@ -297,9 +298,9 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
     void abortNotInLoopThread();
     void wakeup();
     void wakeupRead();
-    volatile bool looping_;
+    std::atomic<bool> looping_;
     std::thread::id threadId_;
-    volatile bool quit_;
+    std::atomic<bool> quit_;
     std::unique_ptr<Poller> poller_;
 
     ChannelList activeChannels_;

--- a/trantor/net/EventLoop.h
+++ b/trantor/net/EventLoop.h
@@ -271,7 +271,8 @@ class TRANTOR_EXPORT EventLoop : NonCopyable
      */
     bool isRunning()
     {
-        return looping_ && (!quit_);
+        return looping_.load(std::memory_order_acquire) &&
+               (!quit_.load(std::memory_order_acquire));
     }
 
     /**


### PR DESCRIPTION
This patch forces the EventLoop destructor to actually wait for the eventloop to exit instead of assuming it exits immediately (and if not) asserting. This is discussed in Issue #1154.