### PR TITLE
Fix logger causes if statement mismatch

### DIFF
--- a/trantor/tests/CMakeLists.txt
+++ b/trantor/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(delayed_ssl_server_test DelayedSSLServerTest.cc)
 add_executable(delayed_ssl_client_test DelayedSSLClientTest.cc)
 add_executable(run_on_quit_test RunOnQuitTest.cc)
 add_executable(path_conversion_test PathConversionTest.cc)
+add_executable(logger_macro_test LoggerMacroTest.cc)
 set(targets_list
     ssl_server_test
     ssl_client_test
@@ -42,7 +43,8 @@ set(targets_list
     delayed_ssl_server_test
     delayed_ssl_client_test
     run_on_quit_test
-    path_conversion_test)
+    path_conversion_test
+    logger_macro_test)
 
 set_property(TARGET ${targets_list} PROPERTY CXX_STANDARD 14)
 set_property(TARGET ${targets_list} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/trantor/tests/LoggerMacroTest.cc
+++ b/trantor/tests/LoggerMacroTest.cc
@@ -5,7 +5,7 @@ using namespace trantor;
 int main()
 {
     trantor::Logger::setLogLevel(trantor::Logger::kInfo);
-    if(0)
+    if (0)
         LOG_INFO << "dummy";
     else
         LOG_WARN << "it works";

--- a/trantor/tests/LoggerMacroTest.cc
+++ b/trantor/tests/LoggerMacroTest.cc
@@ -1,0 +1,12 @@
+#include <trantor/utils/Logger.h>
+
+using namespace trantor;
+
+int main()
+{
+    trantor::Logger::setLogLevel(trantor::Logger::kInfo);
+    if(0)
+        LOG_INFO << "dummy";
+    else
+        LOG_WARN << "it works";
+}

--- a/trantor/utils/Logger.h
+++ b/trantor/utils/Logger.h
@@ -170,7 +170,7 @@ class TRANTOR_EXPORT Logger : public NonCopyable
         static std::vector<
             std::function<void(const char *msg, const uint64_t len)>>
             outputFuncs;
-        TRANTOR_IF_(index < outputFuncs.size())
+        if (index < outputFuncs.size())
         {
             return outputFuncs[index];
         }
@@ -183,7 +183,7 @@ class TRANTOR_EXPORT Logger : public NonCopyable
     static std::function<void()> &flushFunc_(size_t index)
     {
         static std::vector<std::function<void()>> flushFuncs;
-        TRANTOR_IF_(index < flushFuncs.size())
+        if (index < flushFuncs.size())
         {
             return flushFuncs[index];
         }
@@ -385,7 +385,7 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define DLOG_FATAL_IF(cond) \
     TRANTOR_IF_(cond)       \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
-#endif
+#endif 
 
 const char *strerror_tl(int savedErrno);
 }  // namespace trantor

--- a/trantor/utils/Logger.h
+++ b/trantor/utils/Logger.h
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <vector>
 
+#define TRANTOR_IF_(cond) for (int _r = 0; _r == 0 && (cond); _r = 1)
+
 namespace trantor
 {
 /**
@@ -168,7 +170,7 @@ class TRANTOR_EXPORT Logger : public NonCopyable
         static std::vector<
             std::function<void(const char *msg, const uint64_t len)>>
             outputFuncs;
-        if (index < outputFuncs.size())
+        TRANTOR_IF_(index < outputFuncs.size())
         {
             return outputFuncs[index];
         }
@@ -181,7 +183,7 @@ class TRANTOR_EXPORT Logger : public NonCopyable
     static std::function<void()> &flushFunc_(size_t index)
     {
         static std::vector<std::function<void()>> flushFuncs;
-        if (index < flushFuncs.size())
+        TRANTOR_IF_(index < flushFuncs.size())
         {
             return flushFuncs[index];
         }
@@ -219,20 +221,16 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 };
 #ifdef NDEBUG
 #define LOG_TRACE                                                          \
-    for (; false;)                                                         \
+    TRANTOR_IF_(0)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #else
 #define LOG_TRACE                                                          \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kTrace)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define LOG_TRACE_TO(index)                                                \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kTrace)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .setIndex(index)                                                   \
         .stream()
@@ -240,27 +238,19 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #endif
 
 #define LOG_DEBUG                                                          \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kDebug)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
 #define LOG_DEBUG_TO(index)                                                \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kDebug)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .setIndex(index)                                                   \
         .stream()
-#define LOG_INFO                                                          \
-    for (int r = 0;                                                       \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
-         r = 1)                                                           \
+#define LOG_INFO                                                       \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define LOG_INFO_TO(index)                                                \
-    for (int r = 0;                                                       \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
-         r = 1)                                                           \
+#define LOG_INFO_TO(index)                                             \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
     trantor::Logger(__FILE__, __LINE__).setIndex(index).stream()
 #define LOG_WARN \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
@@ -287,95 +277,83 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define LOG_RAW trantor::RawLogger().stream()
 #define LOG_RAW_TO(index) trantor::RawLogger().setIndex(index).stream()
 
-#define LOG_TRACE_IF(cond)                                                     \
-    for (int r = 0;                                                            \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
-         (cond);                                                               \
-         r = 1)                                                                \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)     \
+#define LOG_TRACE_IF(cond)                                                  \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
+                (cond))                                                     \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)  \
         .stream()
-#define LOG_DEBUG_IF(cond)                                                     \
-    for (int r = 0;                                                            \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
-         (cond);                                                               \
-         r = 1)                                                                \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)     \
+#define LOG_DEBUG_IF(cond)                                                  \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
+                (cond))                                                     \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)  \
         .stream()
-#define LOG_INFO_IF(cond)                                                     \
-    for (int r = 0;                                                           \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
-         (cond);                                                              \
-         r = 1)                                                               \
+#define LOG_INFO_IF(cond)                                                  \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
+                (cond))                                                    \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define LOG_WARN_IF(cond)                  \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define LOG_WARN_IF(cond) \
+    TRANTOR_IF_(cond)     \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
-#define LOG_ERROR_IF(cond)                 \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define LOG_ERROR_IF(cond) \
+    TRANTOR_IF_(cond)      \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
-#define LOG_FATAL_IF(cond)                 \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define LOG_FATAL_IF(cond) \
+    TRANTOR_IF_(cond)      \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
 #ifdef NDEBUG
 #define DLOG_TRACE                                                         \
-    for (; false;)                                                         \
+    TRANTOR_IF_(0)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG                                                         \
-    for (; false;)                                                         \
+    TRANTOR_IF_(0)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
 #define DLOG_INFO  \
-    for (; false;) \
+    TRANTOR_IF_(0) \
     trantor::Logger(__FILE__, __LINE__).stream()
 #define DLOG_WARN  \
-    for (; false;) \
+    TRANTOR_IF_(0) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
 #define DLOG_ERROR \
-    for (; false;) \
+    TRANTOR_IF_(0) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
 #define DLOG_FATAL \
-    for (; false;) \
+    TRANTOR_IF_(0) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
 #define DLOG_TRACE_IF(cond)                                                \
-    for (; false;)                                                         \
+    TRANTOR_IF_(0)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG_IF(cond)                                                \
-    for (; false;)                                                         \
+    TRANTOR_IF_(0)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
 #define DLOG_INFO_IF(cond) \
-    for (; false;)         \
+    TRANTOR_IF_(0)         \
     trantor::Logger(__FILE__, __LINE__).stream()
 #define DLOG_WARN_IF(cond) \
-    for (; false;)         \
+    TRANTOR_IF_(0)         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
 #define DLOG_ERROR_IF(cond) \
-    for (; false;)          \
+    TRANTOR_IF_(0)          \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
 #define DLOG_FATAL_IF(cond) \
-    for (; false;)          \
+    TRANTOR_IF_(0)          \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 #else
 #define DLOG_TRACE                                                         \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kTrace)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG                                                         \
-    for (int r = 0;                                                        \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
-         r = 1)                                                            \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kDebug)    \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
-#define DLOG_INFO                                                         \
-    for (int r = 0;                                                       \
-         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
-         r = 1)                                                           \
+#define DLOG_INFO                                                      \
+    TRANTOR_IF_(trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
     trantor::Logger(__FILE__, __LINE__).stream()
 #define DLOG_WARN \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
@@ -384,34 +362,28 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define DLOG_FATAL \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
-#define DLOG_TRACE_IF(cond)                                                    \
-    for (int r = 0;                                                            \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
-         (cond);                                                               \
-         r = 1)                                                                \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)     \
+#define DLOG_TRACE_IF(cond)                                                 \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
+                (cond))                                                     \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)  \
         .stream()
-#define DLOG_DEBUG_IF(cond)                                                    \
-    for (int r = 0;                                                            \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
-         (cond);                                                               \
-         r = 1)                                                                \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)     \
+#define DLOG_DEBUG_IF(cond)                                                 \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
+                (cond))                                                     \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)  \
         .stream()
-#define DLOG_INFO_IF(cond)                                                    \
-    for (int r = 0;                                                           \
-         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
-         (cond);                                                              \
-         r = 1)                                                               \
+#define DLOG_INFO_IF(cond)                                                 \
+    TRANTOR_IF_((trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
+                (cond))                                                    \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define DLOG_WARN_IF(cond)                 \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define DLOG_WARN_IF(cond) \
+    TRANTOR_IF_(cond)      \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
-#define DLOG_ERROR_IF(cond)                \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define DLOG_ERROR_IF(cond) \
+    TRANTOR_IF_(cond)       \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
-#define DLOG_FATAL_IF(cond)                \
-    for (int r = 0; r == 0 && cond; r = 1) \
+#define DLOG_FATAL_IF(cond) \
+    TRANTOR_IF_(cond)       \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 #endif
 

--- a/trantor/utils/Logger.h
+++ b/trantor/utils/Logger.h
@@ -219,16 +219,20 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 };
 #ifdef NDEBUG
 #define LOG_TRACE                                                          \
-    if (0)                                                                 \
+    for (; false;)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #else
 #define LOG_TRACE                                                          \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kTrace)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define LOG_TRACE_TO(index)                                                \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kTrace)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .setIndex(index)                                                   \
         .stream()
@@ -236,19 +240,27 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #endif
 
 #define LOG_DEBUG                                                          \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kDebug)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
 #define LOG_DEBUG_TO(index)                                                \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kDebug)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .setIndex(index)                                                   \
         .stream()
-#define LOG_INFO                                               \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
+#define LOG_INFO                                                          \
+    for (int r = 0;                                                       \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
+         r = 1)                                                           \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define LOG_INFO_TO(index)                                     \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
+#define LOG_INFO_TO(index)                                                \
+    for (int r = 0;                                                       \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
+         r = 1)                                                           \
     trantor::Logger(__FILE__, __LINE__).setIndex(index).stream()
 #define LOG_WARN \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
@@ -275,80 +287,95 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define LOG_RAW trantor::RawLogger().stream()
 #define LOG_RAW_TO(index) trantor::RawLogger().setIndex(index).stream()
 
-#define LOG_TRACE_IF(cond)                                                  \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kTrace) && (cond)) \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)  \
+#define LOG_TRACE_IF(cond)                                                     \
+    for (int r = 0;                                                            \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
+         (cond);                                                               \
+         r = 1)                                                                \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)     \
         .stream()
-#define LOG_DEBUG_IF(cond)                                                  \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kDebug) && (cond)) \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)  \
+#define LOG_DEBUG_IF(cond)                                                     \
+    for (int r = 0;                                                            \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
+         (cond);                                                               \
+         r = 1)                                                                \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)     \
         .stream()
-#define LOG_INFO_IF(cond)                                                  \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kInfo) && (cond)) \
+#define LOG_INFO_IF(cond)                                                     \
+    for (int r = 0;                                                           \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
+         (cond);                                                              \
+         r = 1)                                                               \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define LOG_WARN_IF(cond) \
-    if (cond)             \
+#define LOG_WARN_IF(cond)                  \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
-#define LOG_ERROR_IF(cond) \
-    if (cond)              \
+#define LOG_ERROR_IF(cond)                 \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
-#define LOG_FATAL_IF(cond) \
-    if (cond)              \
+#define LOG_FATAL_IF(cond)                 \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
 #ifdef NDEBUG
 #define DLOG_TRACE                                                         \
-    if (0)                                                                 \
+    for (; false;)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG                                                         \
-    if (0)                                                                 \
+    for (; false;)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
-#define DLOG_INFO \
-    if (0)        \
+#define DLOG_INFO  \
+    for (; false;) \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define DLOG_WARN \
-    if (0)        \
+#define DLOG_WARN  \
+    for (; false;) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
 #define DLOG_ERROR \
-    if (0)         \
+    for (; false;) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
 #define DLOG_FATAL \
-    if (0)         \
+    for (; false;) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
 #define DLOG_TRACE_IF(cond)                                                \
-    if (0)                                                                 \
+    for (; false;)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG_IF(cond)                                                \
-    if (0)                                                                 \
+    for (; false;)                                                         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
 #define DLOG_INFO_IF(cond) \
-    if (0)                 \
+    for (; false;)         \
     trantor::Logger(__FILE__, __LINE__).stream()
 #define DLOG_WARN_IF(cond) \
-    if (0)                 \
+    for (; false;)         \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
 #define DLOG_ERROR_IF(cond) \
-    if (0)                  \
+    for (; false;)          \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
 #define DLOG_FATAL_IF(cond) \
-    if (0)                  \
+    for (; false;)          \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 #else
 #define DLOG_TRACE                                                         \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kTrace)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kTrace; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__) \
         .stream()
 #define DLOG_DEBUG                                                         \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kDebug)            \
+    for (int r = 0;                                                        \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kDebug; \
+         r = 1)                                                            \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__) \
         .stream()
-#define DLOG_INFO                                              \
-    if (trantor::Logger::logLevel() <= trantor::Logger::kInfo) \
+#define DLOG_INFO                                                         \
+    for (int r = 0;                                                       \
+         r == 0 && trantor::Logger::logLevel() <= trantor::Logger::kInfo; \
+         r = 1)                                                           \
     trantor::Logger(__FILE__, __LINE__).stream()
 #define DLOG_WARN \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
@@ -357,25 +384,34 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define DLOG_FATAL \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 
-#define DLOG_TRACE_IF(cond)                                                 \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kTrace) && (cond)) \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)  \
+#define DLOG_TRACE_IF(cond)                                                    \
+    for (int r = 0;                                                            \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kTrace) && \
+         (cond);                                                               \
+         r = 1)                                                                \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kTrace, __func__)     \
         .stream()
-#define DLOG_DEBUG_IF(cond)                                                 \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kDebug) && (cond)) \
-    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)  \
+#define DLOG_DEBUG_IF(cond)                                                    \
+    for (int r = 0;                                                            \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kDebug) && \
+         (cond);                                                               \
+         r = 1)                                                                \
+    trantor::Logger(__FILE__, __LINE__, trantor::Logger::kDebug, __func__)     \
         .stream()
-#define DLOG_INFO_IF(cond)                                                 \
-    if ((trantor::Logger::logLevel() <= trantor::Logger::kInfo) && (cond)) \
+#define DLOG_INFO_IF(cond)                                                    \
+    for (int r = 0;                                                           \
+         r == 0 && (trantor::Logger::logLevel() <= trantor::Logger::kInfo) && \
+         (cond);                                                              \
+         r = 1)                                                               \
     trantor::Logger(__FILE__, __LINE__).stream()
-#define DLOG_WARN_IF(cond) \
-    if (cond)              \
+#define DLOG_WARN_IF(cond)                 \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kWarn).stream()
-#define DLOG_ERROR_IF(cond) \
-    if (cond)               \
+#define DLOG_ERROR_IF(cond)                \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kError).stream()
-#define DLOG_FATAL_IF(cond) \
-    if (cond)               \
+#define DLOG_FATAL_IF(cond)                \
+    for (int r = 0; r == 0 && cond; r = 1) \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
 #endif
 

--- a/trantor/utils/Logger.h
+++ b/trantor/utils/Logger.h
@@ -385,7 +385,7 @@ class TRANTOR_EXPORT RawLogger : public NonCopyable
 #define DLOG_FATAL_IF(cond) \
     TRANTOR_IF_(cond)       \
     trantor::Logger(__FILE__, __LINE__, trantor::Logger::kFatal).stream()
-#endif 
+#endif
 
 const char *strerror_tl(int savedErrno);
 }  // namespace trantor


### PR DESCRIPTION
This PR fixes loggers not printing anything when used in a `if` statement without {}.

For example. The following simple program prints nothing in current master

```c++
    if(0)
        LOG_INFO << "dummy";
    else
        LOG_WARN << "it works";
```

This is due to LOG_INFO and LOG_WARN are in fact macros. And expands to

```c++
    if(0)
        if(trantor::Logger::logLevel() <= trantor::Logger::kInfo) trantor::Logger...stream()<< "dummy";
    else
        if(trantor::Logger::logLevel() <= trantor::Logger::kWarn) trantor::Logger...stream() << "it works";
```

Which is intepered by c++ as 


```c++
    if(0) {
        if(trantor::Logger::logLevel() <= trantor::Logger::kInfo)
             trantor::Logger...stream()<< "dummy";
        else if(trantor::Logger::logLevel() <= trantor::Logger::kWarn) 
             trantor::Logger...stream() << "it works";
    }
```

The patch replaces `if` with `for` to avoid C++ from misintercepting the result.