### PR TITLE
Stop calling abort() in runtime.

### DIFF
--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -153,7 +153,7 @@ void TcpClient::newConnection(int sockfd)
                                                    SSLHostName_);
 #else
         LOG_FATAL << "OpenSSL is not found in your system!";
-        abort();
+        throw std::runtime_error("OpenSSL is not found in your system!");
 #endif
     }
     else
@@ -253,6 +253,6 @@ void TcpClient::enableSSL(
     (void)keyPath;
 
     LOG_FATAL << "OpenSSL is not found in your system!";
-    abort();
+    throw std::runtime_error("OpenSSL is not found in your system!");
 #endif
 }

--- a/trantor/net/TcpServer.cc
+++ b/trantor/net/TcpServer.cc
@@ -76,7 +76,7 @@ void TcpServer::newConnection(int sockfd, const InetAddress &peer)
             sslCtxPtr_);
 #else
         LOG_FATAL << "OpenSSL is not found in your system!";
-        abort();
+        throw std::runtime_error("OpenSSL is not found in your system!");
 #endif
     }
     else
@@ -223,6 +223,6 @@ void TcpServer::enableSSL(
     (void)sslConfCmds;
 
     LOG_FATAL << "OpenSSL is not found in your system!";
-    abort();
+    throw std::runtime_error("OpenSSL is not found in your system!");
 #endif
 }

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -327,7 +327,7 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Reading certificate: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_use_certificate_chain_file error.");
     }
     r = SSL_CTX_use_PrivateKey_file(ctx->get(),
                                     keyPath.c_str(),
@@ -336,14 +336,14 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Reading private key: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_use_PrivateKey_file error");
     }
     r = SSL_CTX_check_private_key(ctx->get());
     if (!r)
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Checking private key matches certificate: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_check_private_key error");
     }
     return ctx;
 }
@@ -364,7 +364,7 @@ std::shared_ptr<SSLContext> newSSLClientContext(
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Reading certificate: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_use_certificate_chain_file error.");
     }
     r = SSL_CTX_use_PrivateKey_file(ctx->get(),
                                     keyPath.c_str(),
@@ -373,14 +373,14 @@ std::shared_ptr<SSLContext> newSSLClientContext(
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Reading private key: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_use_PrivateKey_file error.");
     }
     r = SSL_CTX_check_private_key(ctx->get());
     if (!r)
     {
         ERR_error_string_n(ERR_get_error(), errbuf, sizeof(errbuf));
         LOG_FATAL << "Checking private key matches certificate: " << errbuf;
-        abort();
+        throw std::runtime_error("SSL_CTX_check_private_key error.");
     }
     return ctx;
 }
@@ -395,7 +395,7 @@ std::shared_ptr<SSLContext> newSSLServerContext(
     const std::vector<std::pair<std::string, std::string>> &)
 {
     LOG_FATAL << "OpenSSL is not found in your system!";
-    abort();
+    throw std::runtime_error("OpenSSL is not found in your system!");
 }
 }  // namespace trantor
 #endif
@@ -513,7 +513,7 @@ void TcpConnectionImpl::startServerEncryption(
     (void)callback;
 
     LOG_FATAL << "OpenSSL is not found in your system!";
-    abort();
+    throw std::runtime_error("OpenSSL is not found in your system!");
 #else
     if (loop_->isInLoopThread())
     {
@@ -547,7 +547,7 @@ void TcpConnectionImpl::startClientEncryption(
     (void)sslConfCmds;
 
     LOG_FATAL << "OpenSSL is not found in your system!";
-    abort();
+    throw std::runtime_error("OpenSSL is not found in your system!");
 #else
     if (!hostname.empty())
     {


### PR DESCRIPTION
应用程序可能错误的调用了这些代码，或者配置出现了部分错误。这种情况下应用程序可以被正常启动并运行，直到触发了这些代码, abort() 被调用。我认为正确的表现应该是出现问题的那部分功能不可用，而不应该是整个应用程序的崩溃。使用 abort() 导致错误无法挽回(不能被try catch)，也无法反馈任何信息给用户。