### PR TITLE
include <pthread_np.h> unconditionally on freebsd

### DIFF
--- a/trantor/utils/Logger.cc
+++ b/trantor/utils/Logger.cc
@@ -24,7 +24,9 @@
 #include <unistd.h>
 #elif defined _WIN32
 #include <sstream>
-#elif defined __FreeBSD__
+#endif
+
+#if defined __FreeBSD__
 #include <pthread_np.h>
 #endif
 


### PR DESCRIPTION
Small buildfix for FreeBSD. The include in the `#ifdef` block should always be added on FreeBSD, but was never hit because `__unix__` is also defined on this platform.