### PR TITLE
Fix tolower with sanitizer cfi

### DIFF
--- a/trantor/net/TcpClient.cc
+++ b/trantor/net/TcpClient.cc
@@ -238,7 +238,7 @@ void TcpClient::enableSSL(
         std::transform(hostname.begin(),
                        hostname.end(),
                        hostname.begin(),
-                       tolower);
+                       [](unsigned char c) { return tolower(c); });
         SSLHostName_ = std::move(hostname);
     }
 

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -554,7 +554,7 @@ void TcpConnectionImpl::startClientEncryption(
         std::transform(hostname.begin(),
                        hostname.end(),
                        hostname.begin(),
-                       tolower);
+                       [](unsigned char c) { return tolower(c); });
         assert(sslEncryptionPtr_ != nullptr);
         sslEncryptionPtr_->hostname_ = hostname;
     }


### PR DESCRIPTION
Related to https://github.com/drogonframework/drogon/issues/1209

Using `tolower` in `std::transform` is a violation of cfi sanitizer (Control Flow Integrity). According to https://en.cppreference.com/w/cpp/string/byte/tolower, use `[](unsigned char c){ return std::tolower(c); }`