### PR TITLE
Optimization SSL name matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cmake-build-debug
 .vscode
 .vs
 CMakeSettings.json
+.cache

--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -86,43 +86,6 @@ inline bool loadWindowsSystemCert(X509_STORE *store)
 }
 #endif
 
-inline bool verifyName(const std::string &certName, const std::string &hostname)
-{
-    size_t firstDot = certName.find('.');
-    size_t hostFirstDot = hostname.find('.');
-    size_t pos, len, hostPos, hostLen;
-
-    if (firstDot != std::string::npos)
-    {
-        pos = firstDot + 1;
-    }
-    else
-    {
-        firstDot = pos = certName.size();
-    }
-
-    len = certName.size() - pos;
-
-    if (hostFirstDot != std::string::npos)
-    {
-        hostPos = hostFirstDot + 1;
-    }
-    else
-    {
-        hostFirstDot = hostPos = hostname.size();
-    }
-
-    hostLen = hostname.size() - hostPos;
-
-    if (certName.compare(0, firstDot, "*") == 0)
-    {
-        return certName.compare(pos, len, hostname) == 0 ||
-               certName.compare(pos, len, hostname, hostPos, hostLen) == 0;
-    }
-
-    return certName == hostname;
-}
-
 inline bool verifyCommonName(X509 *cert, const std::string &hostname)
 {
     X509_NAME *subjectName = X509_get_subject_name(cert);
@@ -137,8 +100,9 @@ inline bool verifyCommonName(X509 *cert, const std::string &hostname)
         if (length == -1)
             return false;
 
-        return verifyName(std::string(name.begin(), name.begin() + length),
-                          hostname);
+        return utils::verifySslName(std::string(name.begin(),
+                                                name.begin() + length),
+                                    hostname);
     }
 
     return false;
@@ -169,7 +133,8 @@ inline bool verifyAltName(X509 *cert, const std::string &hostname)
             auto name = (const char *)ASN1_STRING_data(val->d.ia5);
 #endif
             auto name_len = (size_t)ASN1_STRING_length(val->d.ia5);
-            good = verifyName(std::string(name, name + name_len), hostname);
+            good = utils::verifySslName(std::string(name, name + name_len),
+                                        hostname);
         }
     }
 

--- a/trantor/unittests/CMakeLists.txt
+++ b/trantor/unittests/CMakeLists.txt
@@ -4,12 +4,14 @@ add_executable(inetaddress_unittest InetAddressUnittest.cc)
 add_executable(date_unittest DateUnittest.cc)
 add_executable(split_string_unittest splitStringUnittest.cc)
 add_executable(string_encoding_unittest stringEncodingUnittest.cc)
+add_executable(ssl_name_verify_unittest sslNameVerifyUnittest.cc)
 set(UNITTEST_TARGETS
     msgbuffer_unittest
     inetaddress_unittest
     date_unittest
     split_string_unittest
-    string_encoding_unittest)
+    string_encoding_unittest
+    ssl_name_verify_unittest)
 set_property(TARGET ${UNITTEST_TARGETS} PROPERTY CXX_STANDARD 14)
 set_property(TARGET ${UNITTEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${UNITTEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)

--- a/trantor/unittests/sslNameVerifyUnittest.cc
+++ b/trantor/unittests/sslNameVerifyUnittest.cc
@@ -1,0 +1,50 @@
+#include <trantor/utils/Utilities.h>
+#include <gtest/gtest.h>
+#include <iostream>
+using namespace trantor;
+using namespace trantor::utils;
+
+TEST(sslNameCheck, baseCases)
+{
+    EXPECT_EQ(verifySslName("example.com", "example.com"), true);
+    EXPECT_EQ(verifySslName("example.com", "example.org"), false);
+    EXPECT_EQ(verifySslName("example.com", "www.example.com"), false);
+}
+
+TEST(sslNameCheck, rfc6125Examples)
+{
+    EXPECT_EQ(verifySslName("*.example.com", "foo.example.com"), true);
+    EXPECT_EQ(verifySslName("*.example.com", "foo.bar.example.com"), false);
+    EXPECT_EQ(verifySslName("*.example.com", "example.com"), false);
+    EXPECT_EQ(verifySslName("*bar.example.com", "foobar.example.com"), true);
+    EXPECT_EQ(verifySslName("baz*.example.com", "baz1.example.com"), true);
+    EXPECT_EQ(verifySslName("b*z.example.com", "buzz.example.com"), true);
+}
+
+TEST(sslNameCheck, rfcCounterExamples)
+{
+    EXPECT_EQ(verifySslName("buz*.example.com", "buaz.example.com"), false);
+    EXPECT_EQ(verifySslName("*bar.example.com", "aaasdasbaz.example.com"),
+              false);
+    EXPECT_EQ(verifySslName("b*z.example.com", "baaaaaa.example.com"), false);
+}
+
+TEST(sslNameCheck, wildExamples)
+{
+    EXPECT_EQ(verifySslName("datatracker.ietf.org", "datatracker.ietf.org"),
+              true);
+    EXPECT_EQ(verifySslName("*.nsysu.edu.tw", "nsysu.edu.tw"), false);
+    EXPECT_EQ(verifySslName("nsysu.edu.tw", "nsysu.edu.tw"), true);
+}
+
+TEST(sslNameCheck, edgeCase)
+{
+    EXPECT_EQ(verifySslName(".example.com", "example.com"), false);
+    EXPECT_EQ(verifySslName("example.com.", "example.com."), true);
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/trantor/utils/Utilities.cc
+++ b/trantor/utils/Utilities.cc
@@ -25,7 +25,6 @@
 #include <codecvt>
 #endif  // __cplusplus
 #endif  // _WIN32
-#include <iostream>
 
 namespace trantor
 {

--- a/trantor/utils/Utilities.cc
+++ b/trantor/utils/Utilities.cc
@@ -25,6 +25,7 @@
 #include <codecvt>
 #endif  // __cplusplus
 #endif  // _WIN32
+#include <iostream>
 
 namespace trantor
 {
@@ -130,6 +131,119 @@ std::string fromWidePath(const std::wstring &wstrPath)
     auto &srcPath{wstrPath};
 #endif  // _WIN32
     return toUtf8(srcPath);
+}
+
+bool verifySslName(const std::string &certName, const std::string &hostname)
+{
+    if (certName.find('*') == std::string::npos)
+    {
+        return certName == hostname;
+    }
+
+    size_t firstDot = certName.find('.');
+    size_t hostFirstDot = hostname.find('.');
+    size_t pos, len, hostPos, hostLen;
+
+    if (firstDot != std::string::npos)
+    {
+        pos = firstDot + 1;
+    }
+    else
+    {
+        firstDot = pos = certName.size();
+    }
+
+    len = certName.size() - pos;
+
+    if (hostFirstDot != std::string::npos)
+    {
+        hostPos = hostFirstDot + 1;
+    }
+    else
+    {
+        hostFirstDot = hostPos = hostname.size();
+    }
+
+    hostLen = hostname.size() - hostPos;
+
+    // *. in the beginning of the cert name
+    if (certName.compare(0, firstDot, "*") == 0)
+    {
+        return certName.compare(pos, len, hostname, hostPos, hostLen) == 0;
+    }
+    // * in the left most. but other chars in the right
+    else if (certName[0] == '*')
+    {
+        // compare if `hostname` ends with `certName` but without the leftmost
+        // should be fine as domain names can't be that long
+        intmax_t hostnameIdx = hostname.size() - 1;
+        intmax_t certNameIdx = certName.size() - 1;
+        while (hostnameIdx >= 0 && certNameIdx != 0)
+        {
+            if (hostname[hostnameIdx] != certName[certNameIdx])
+            {
+                return false;
+            }
+            hostnameIdx--;
+            certNameIdx--;
+        }
+        if (certNameIdx != 0)
+        {
+            return false;
+        }
+        return true;
+    }
+    // * in the right of the first dot
+    else if (firstDot != 0 && certName[firstDot - 1] == '*')
+    {
+        if (certName.compare(pos, len, hostname, hostPos, hostLen) != 0)
+        {
+            return false;
+        }
+        for (size_t i = 0;
+             i < hostFirstDot && i < firstDot && certName[i] != '*';
+             i++)
+        {
+            if (hostname[i] != certName[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    // else there's a * in  the middle
+    else
+    {
+        if (certName.compare(pos, len, hostname, hostPos, hostLen) != 0)
+        {
+            return false;
+        }
+        for (size_t i = 0;
+             i < hostFirstDot && i < firstDot && certName[i] != '*';
+             i++)
+        {
+            if (hostname[i] != certName[i])
+            {
+                return false;
+            }
+        }
+        intmax_t hostnameIdx = hostFirstDot - 1;
+        intmax_t certNameIdx = firstDot - 1;
+        while (hostnameIdx >= 0 && certNameIdx >= 0 &&
+               certName[certNameIdx] != '*')
+        {
+            if (hostname[hostnameIdx] != certName[certNameIdx])
+            {
+                return false;
+            }
+            hostnameIdx--;
+            certNameIdx--;
+        }
+        return true;
+    }
+
+    // should not reach
+    return certName == hostname;
 }
 
 }  // namespace utils

--- a/trantor/utils/Utilities.h
+++ b/trantor/utils/Utilities.h
@@ -173,8 +173,10 @@ inline std::string fromNativePath(const std::wstring &strPath)
 
 /**
  * @brief Check if the name supplied by the SSL Cert matchs a FQDN
+ * @param certName The name supplied by the SSL Cert
+ * @param hostName The FQDN to match
  *
- * @ return true if matches. false otherwise
+ * @return true if matches. false otherwise
  */
 bool verifySslName(const std::string &certName, const std::string &hostname);
 

--- a/trantor/utils/Utilities.h
+++ b/trantor/utils/Utilities.h
@@ -171,6 +171,13 @@ inline std::string fromNativePath(const std::wstring &strPath)
     return fromWidePath(strPath);
 }
 
+/**
+ * @brief Check if the name supplied by the SSL Cert matchs a FQDN
+ *
+ * @ return true if matches. false otherwise
+ */
+bool verifySslName(const std::string &certName, const std::string &hostname);
+
 }  // namespace utils
 
 }  // namespace trantor


### PR DESCRIPTION
This PR is aimed at Optimization SSL name matching. 
In the original way it uses Regex to match the SSL name, but it is slow.