### PR TITLE
Rename BUILD_TRANTOR_SHARED to BUILD_SHARED_LIBS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./build
         run: |
           [[ ${{ matrix.link }} == "SHARED" ]] && shared="ON" || shared="OFF"
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=on -DBUILD_TRANTOR_SHARED=$shared -DCMAKE_TOOLCHAIN_FILE="conan_paths.cmake" -DCMAKE_INSTALL_PREFIX=../install
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=on -DBUILD_SHARED_LIBS=$shared -DCMAKE_TOOLCHAIN_FILE="conan_paths.cmake" -DCMAKE_INSTALL_PREFIX=../install
 
       - name: Build
         working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(trantor)
 
 option(BUILD_DOC "Build Doxygen documentation" OFF)
 option(BUILD_C-ARES "Build C-ARES" ON)
+option(BUILD_SHARED_LIBS "Build trantor as a shared lib" OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
 
@@ -24,14 +25,13 @@ set(INSTALL_TRANTOR_CMAKE_DIR
     ${DEF_INSTALL_TRANTOR_CMAKE_DIR}
     CACHE PATH "Installation directory for cmake files")
 
-if(BUILD_TRANTOR_SHARED)
-  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+add_library(${PROJECT_NAME})
+if(BUILD_SHARED_LIBS)
   list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
             "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}" isSystemDir)
   if("${isSystemDir}" STREQUAL "-1")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}")
   endif("${isSystemDir}" STREQUAL "-1")
-  add_library(${PROJECT_NAME} SHARED)
   set_target_properties(${PROJECT_NAME} PROPERTIES
       VERSION ${TRANTOR_VERSION}
       SOVERSION ${TRANTOR_MAJOR_VERSION})
@@ -42,9 +42,7 @@ if(BUILD_TRANTOR_SHARED)
     # exact same compiler for drogon and your app.
     target_compile_options(${PROJECT_NAME} PUBLIC /wd4251 /wd4275)
   endif()
-else(BUILD_TRANTOR_SHARED)
-  add_library(${PROJECT_NAME} STATIC)
-endif(BUILD_TRANTOR_SHARED)
+endif(BUILD_SHARED_LIBS)
 
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" AND CMAKE_CXX_COMPILER_ID MATCHES Clang|GNU)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror)


### PR DESCRIPTION
Use official variable name to build shared library.

You don't need to add static/shared when calling [add_library](https://cmake.org/cmake/help/latest/command/add_library.html) and [CMAKE_POSITION_INDEPENDENT_CODE](https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html#prop_tgt:POSITION_INDEPENDENT_CODE) is automatically set to the good value.