### PR TITLE
Partial fix of exception safety in the event loop

### DIFF
--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -182,14 +182,14 @@ namespace
 template <typename F>
 struct ScopeExit
 {
-    ScopeExit(F &&f) : m_f(std::forward<F>(f))
+    ScopeExit(F &&f) : f_(std::forward<F>(f))
     {
     }
     ~ScopeExit()
     {
-        m_f();
+        f_();
     }
-    F m_f;
+    F f_;
 };
 
 template <typename F>
@@ -246,7 +246,7 @@ void EventLoop::loop()
     }
 
     // Run the quit functions even if exceptions were thrown
-    // TOOD: if more exceptions are thrown in the quit functions, some are left
+    // TODO: if more exceptions are thrown in the quit functions, some are left
     // un-run. Can this be made exception safe?
     Func f;
     while (funcsOnQuit_.dequeue(f))
@@ -257,7 +257,7 @@ void EventLoop::loop()
     // Throw the exception from the end
     if (loopException)
     {
-        LOG_WARN << "Rethrowing exception from even loop";
+        LOG_WARN << "Rethrowing exception from event loop";
         std::rethrow_exception(loopException);
     }
 }


### PR DESCRIPTION
Previously, if an exception was thrown from the event loop, the whole app would hang in `EventLoop::~EventLoop()`. Fix that by adding a simple scope guard for the loop flag in `EventLoop::loop()`. In addition, catch the exception and allow the `funcsOnQuit`s to run, before rethrowing.

Also superficially fix another similar bug in `doRunInLoopFuncs()`, although as the comments point out, it's exception safety is still under question.

Overall, this exposes another bug whose source is still unclear: if an exception is thrown in a loop function, the program ultimately exits with `FATAL It is forbidden to run loop on threads other than event-loop thread - EventLoop.cc:258. However, this is still better than the previous hang.

Partially addresses [Drogon::1157](https://github.com/drogonframework/drogon/issues/1157)

N.B. We could also run `funcsOnQuit` in the scope guard, though this means that if any function there throws, it'll happen in a destructor while rewinding stack due to an exception, so a double fault and `terminate()` is called immediately. Might nonetheless be the cleaner option?