### PR TITLE
Fix socket fd leak if Connector destruct before connection callback is made

### DIFF
--- a/trantor/net/inner/Connector.cc
+++ b/trantor/net/inner/Connector.cc
@@ -32,9 +32,9 @@ Connector::~Connector()
     if (socketHanded_ == false && fd_ != -1)
     {
 #ifndef _WIN32
-            ::close(fd_);
+        ::close(fd_);
 #else
-            closesocket(fd_);
+        closesocket(fd_);
 #endif
     }
 }

--- a/trantor/net/inner/Connector.cc
+++ b/trantor/net/inner/Connector.cc
@@ -31,13 +31,17 @@ Connector::~Connector()
 {
     if (socketHanded_ == false && fd_ != -1)
     {
-        close(fd_);
+#ifndef _WIN32
+            ::close(fd_);
+#else
+            closesocket(fd_);
+#endif
     }
 }
 
 void Connector::start()
 {
-    connect_.store(true, std::memory_order_acquire);
+    connect_.store(true, std::memory_order_acq_rel);
     loop_->runInLoop([this]() { startInLoop(); });
 }
 void Connector::restart()

--- a/trantor/net/inner/Connector.cc
+++ b/trantor/net/inner/Connector.cc
@@ -41,7 +41,7 @@ Connector::~Connector()
 
 void Connector::start()
 {
-    connect_.store(true, std::memory_order_acq_rel);
+    connect_ = true;
     loop_->runInLoop([this]() { startInLoop(); });
 }
 void Connector::restart()

--- a/trantor/net/inner/Connector.h
+++ b/trantor/net/inner/Connector.h
@@ -77,7 +77,7 @@ class Connector : public NonCopyable,
     int maxRetryInterval_{kMaxRetryDelayMs};
 
     bool retry_;
-    bool sockedHanded_{false};
+    bool socketHanded_{false};
     int fd_{-1};
 
     void startInLoop();

--- a/trantor/net/inner/Connector.h
+++ b/trantor/net/inner/Connector.h
@@ -30,6 +30,7 @@ class Connector : public NonCopyable,
     using ConnectionErrorCallback = std::function<void()>;
     Connector(EventLoop *loop, const InetAddress &addr, bool retry = true);
     Connector(EventLoop *loop, InetAddress &&addr, bool retry = true);
+    ~Connector();
     void setNewConnectionCallback(const NewConnectionCallback &cb)
     {
         newConnectionCallback_ = cb;
@@ -76,6 +77,8 @@ class Connector : public NonCopyable,
     int maxRetryInterval_{kMaxRetryDelayMs};
 
     bool retry_;
+    bool sockedHanded_{false};
+    int fd_{-1};
 
     void startInLoop();
     void connect();


### PR DESCRIPTION
Currently there is a file descriptor leak in Connector. When the remote host does not create the TCP connection in a timely way. Causing the HTTP client in Drogon to timeout before Connector creates a channel. This can lead to the HTTP client (thus the `TcpClient` and thus the `Connection`, depending on how it's used) to destruct before an IO channel is created. This causes the file descriptor to not be closed. Causing a file descriptor leak

```c++
void Connector::connect()
{
    // this one. Not RAII handled
    int socketfd = Socket::createNonblockingSocketOrDie(serverAddr_.family());
```

This patch fixes this by explicitly checking and closing the created socket if `Connection` destructed before calling any of it's callbacks.