### PR TITLE
Add missing <cstdint> header with GCC 13

### DIFF
--- a/trantor/utils/Funcs.h
+++ b/trantor/utils/Funcs.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <algorithm>
 #include <vector>
+#include <cstdint>
 namespace trantor
 {
 inline uint64_t hton64(uint64_t n)

--- a/trantor/utils/MsgBuffer.h
+++ b/trantor/utils/MsgBuffer.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <cstdint>
 #ifdef _WIN32
 using ssize_t = std::intptr_t;
 #endif


### PR DESCRIPTION
Added missing headers `<cstdint>` to fix build with GCC 13.
ref: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes