### PR TITLE
Fix assertInLoopThread assertion in AresResolver during destruction

### DIFF
--- a/trantor/net/inner/AresResolver.cc
+++ b/trantor/net/inner/AresResolver.cc
@@ -202,9 +202,6 @@ void AresResolver::onSockCreate(int sockfd, int type)
 void AresResolver::onSockStateChange(int sockfd, bool read, bool write)
 {
     (void)write;
-    loop_->assertInLoopThread();
-    ChannelList::iterator it = channels_.find(sockfd);
-    assert(it != channels_.end());
     if (read)
     {
         // update
@@ -212,6 +209,9 @@ void AresResolver::onSockStateChange(int sockfd, bool read, bool write)
     }
     else if (*loopValid_)
     {
+        loop_->assertInLoopThread();
+        ChannelList::iterator it = channels_.find(sockfd);
+        assert(it != channels_.end());
         // remove
         it->second->disableAll();
         it->second->remove();


### PR DESCRIPTION
Fixes #229

This is the fix I proposed there and I've been using this locally for a while now with no issues.

