### PR TITLE
Added NetEndian versions of `toIp` and `toIpPort`

### DIFF
--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -113,6 +113,21 @@ class TRANTOR_EXPORT InetAddress
     std::string toIpPort() const;
 
     /**
+     * @brief Return the IP bytes of the endpoint in net endian byte order
+     *
+     * @return std::string
+     */
+    std::string toIpNetEndian() const;
+
+    /**
+     * @brief Return the IP and port bytes of the endpoint in net endian byte
+     * order
+     *
+     * @return std::string
+     */
+    std::string toIpPortNetEndian() const;
+
+    /**
      * @brief Return the port number of the endpoint.
      *
      * @return uint16_t

--- a/trantor/unittests/InetAddressUnittest.cc
+++ b/trantor/unittests/InetAddressUnittest.cc
@@ -17,10 +17,8 @@ TEST(InetAddress, innerIpTest)
 }
 TEST(InetAddress, toIpPortNetEndianTest)
 {
-    EXPECT_EQ(
-        std::string(
-            {char(192), char(168), 0, 1, (80 & 0xff00) >> 8, 80 & 0x00ff}),
-        InetAddress("192.168.0.1", 80).toIpPortNetEndian());
+    EXPECT_EQ(std::string({char(192), char(168), 0, 1, 0, 80}),
+              InetAddress("192.168.0.1", 80).toIpPortNetEndian());
     EXPECT_EQ(std::string({0x20,
                            0x01,
                            0x0d,
@@ -37,8 +35,8 @@ TEST(InetAddress, toIpPortNetEndianTest)
                            0x77,
                            char(0x88),
                            char(0x88),
-                           char((443 & 0xff00) >> 8),
-                           char(443 & 0x00ff)}),
+                           1,
+                           char(187)}),
               InetAddress("2001:0db8:3333:4444:5555:6666:7777:8888", 443, true)
                   .toIpPortNetEndian());
 }

--- a/trantor/unittests/InetAddressUnittest.cc
+++ b/trantor/unittests/InetAddressUnittest.cc
@@ -15,6 +15,33 @@ TEST(InetAddress, innerIpTest)
     EXPECT_EQ(false, InetAddress("127.0.0.2", 0).isUnspecified());
     EXPECT_EQ(false, InetAddress("0.0.0.0", 0).isUnspecified());
 }
+TEST(InetAddress, toIpPortNetEndianTest)
+{
+    EXPECT_EQ(
+        std::string(
+            {char(192), char(168), 0, 1, (80 & 0xff00) >> 8, 80 & 0x00ff}),
+        InetAddress("192.168.0.1", 80).toIpPortNetEndian());
+    EXPECT_EQ(std::string({0x20,
+                           0x01,
+                           0x0d,
+                           char(0xb8),
+                           0x33,
+                           0x33,
+                           0x44,
+                           0x44,
+                           0x55,
+                           0x55,
+                           0x66,
+                           0x66,
+                           0x77,
+                           0x77,
+                           char(0x88),
+                           char(0x88),
+                           char((443 & 0xff00) >> 8),
+                           char(443 & 0x00ff)}),
+              InetAddress("2001:0db8:3333:4444:5555:6666:7777:8888", 443, true)
+                  .toIpPortNetEndian());
+}
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Adds pure byte versions of toIp and toIpPort, they are compact and use less memory, while also accounting for ipv4 and ipv6.