### PR TITLE
Fixes bug with Trantor::Date timeZoneOffset calculation

### DIFF
--- a/trantor/utils/Date.h
+++ b/trantor/utils/Date.h
@@ -77,7 +77,8 @@ class TRANTOR_EXPORT Date
     static int64_t timezoneOffset()
     {
         static int64_t offset =
-            -Date::fromDbStringLocal("1970-01-01 00:00:00").secondsSinceEpoch();
+        -(Date::fromDbStringLocal("1970-01-03 00:00:00").secondsSinceEpoch() -
+          2LL * 3600LL * 24LL * MICRO_SECONDS_PRE_SEC);
         return offset;
     }
 

--- a/trantor/utils/Date.h
+++ b/trantor/utils/Date.h
@@ -76,9 +76,9 @@ class TRANTOR_EXPORT Date
 
     static int64_t timezoneOffset()
     {
-        static int64_t offset =
-        -(Date::fromDbStringLocal("1970-01-03 00:00:00").secondsSinceEpoch() -
-          2LL * 3600LL * 24LL * MICRO_SECONDS_PRE_SEC);
+        static int64_t offset = -(
+            Date::fromDbStringLocal("1970-01-03 00:00:00").secondsSinceEpoch() -
+            2LL * 3600LL * 24LL * MICRO_SECONDS_PRE_SEC);
         return offset;
     }
 


### PR DESCRIPTION
Fixes bug #1676. Current implementation returns negative values of offset for timezones UTC+1,UTC+2 etc, but negative values are considered as error, returned error code -1 was used as timezone offset 1 second. Proposed change in this pull request uses 1970-01-03 date for the same calculation without negative values of time epoch. If you have questions and proposals regarding this pull request, please contact me. 