### PR TITLE
Fixes bug with Trantor::Date timeZoneOffset calculation (additional change)

### DIFF
--- a/trantor/utils/Date.h
+++ b/trantor/utils/Date.h
@@ -78,7 +78,7 @@ class TRANTOR_EXPORT Date
     {
         static int64_t offset = -(
             Date::fromDbStringLocal("1970-01-03 00:00:00").secondsSinceEpoch() -
-            2LL * 3600LL * 24LL );
+            2LL * 3600LL * 24LL);
         return offset;
     }
 

--- a/trantor/utils/Date.h
+++ b/trantor/utils/Date.h
@@ -78,7 +78,7 @@ class TRANTOR_EXPORT Date
     {
         static int64_t offset = -(
             Date::fromDbStringLocal("1970-01-03 00:00:00").secondsSinceEpoch() -
-            2LL * 3600LL * 24LL * MICRO_SECONDS_PRE_SEC);
+            2LL * 3600LL * 24LL );
         return offset;
     }
 


### PR DESCRIPTION
In previous my pull request the fix of bug created additional bug due to wrong conversion to seconds. This pull request fixes my bug (removes constant, that is not needed for calculation). 
This bug affected Date::toDbString() and Date::fromDbString() .
