### PR TITLE
Fix build error on OpenBSD

### DIFF
--- a/trantor/utils/Logger.cc
+++ b/trantor/utils/Logger.cc
@@ -393,7 +393,7 @@ void Logger::enableSpdLog(int index, std::shared_ptr<spdlog::logger> logger)
     spdLoggers[index] = logger ? logger : getDefaultSpdLogger(index);
 #else
     (void)index;
-    (bool)logger;
+    (void)logger;
 #endif  // TRANTOR_SPDLOG_SUPPORT
 }
 

--- a/trantor/utils/crypto/openssl.cc
+++ b/trantor/utils/crypto/openssl.cc
@@ -87,8 +87,8 @@ Hash256 sha256(const void* data, size_t len)
 
 Hash256 sha3(const void* data, size_t len)
 {
-#if OPENSSL_VERSION_MAJOR >= 3
     Hash256 hash;
+#if OPENSSL_VERSION_MAJOR >= 3
     auto sha3 = EVP_MD_fetch(nullptr, "SHA3-256", nullptr);
     if (sha3 != nullptr)
     {

--- a/trantor/utils/crypto/openssl.cc
+++ b/trantor/utils/crypto/openssl.cc
@@ -101,7 +101,6 @@ Hash256 sha3(const void* data, size_t len)
         return hash;
     }
 #elif !defined(LIBRESSL_VERSION_NUMBER)
-    Hash256 hash;
     auto sha3 = EVP_sha3_256();
     if (sha3 != nullptr)
     {


### PR DESCRIPTION
Fix a few minor bugs that cause drogon to fail to build on OpenBSD.

After the PR drogon and trantor runs correctly on OpenBSD 7.4

```
obsdev$ ./drogon_ctl/drogon_ctl version
     _
  __| |_ __ ___   __ _  ___  _ __
 / _` | '__/ _ \ / _` |/ _ \| '_ \
| (_| | | | (_) | (_| | (_) | | | |
 \__,_|_|  \___/ \__, |\___/|_| |_|
                 |___/

A utility for drogon
Version: 1.9.0
Git commit: f215cb15a0f53abd0ca7ee8b95ed8c9c3b40d262
Compilation: 
  Compiler: c++
  Compiler ID: Clang
  Compilation flags: -std=c++17 -I/usr/local/include
Libraries: 
  postgresql: no  (pipeline mode: no)
  mariadb: no
  sqlite3: yes
  ssl/tls backend: OpenSSL
  brotli: no
  hiredis: no
  c-ares: no
  yaml-cpp: no
obsdev$ uname -a
OpenBSD obsdev.my.domain 7.4 GENERIC.MP#1397 amd64

```