### PR TITLE
Fix c-ares CARES_EXTERN for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,9 @@ if (BUILD_C-ARES)
 endif ()
 
 if(HAVE_C-ARES)
+  if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE CARES_STATICLIB)
+  endif ()
   target_link_libraries(${PROJECT_NAME} PRIVATE c-ares_lib)
   set(TRANTOR_SOURCES
       ${TRANTOR_SOURCES}


### PR DESCRIPTION
When building a drogon with a static c-ares, linker outputs multiple errors like this:
```
ld.lld: error: undefined symbol: __declspec(dllimport) ares_library_init
>>> referenced by libtrantor.a(AresResolver.cc.obj):(trantor::AresResolver::LibraryInitializer::LibraryInitializer())
>>> referenced by libtrantor.a(AresResolver.cc.obj):(_GLOBAL__sub_I_AresResolver.cc)
```
This patch fixes the errors setting `CARES_STATICLIB` for static build, as expected by c-ares in ares.h (line 101):
```
#if defined(_WIN32) || defined(__CYGWIN__) || defined(__SYMBIAN32__)
#  ifdef CARES_STATICLIB
#    define CARES_EXTERN
#  else
#    ifdef CARES_BUILDING_LIBRARY
#      define CARES_EXTERN __declspec(dllexport)
#    else
#      define CARES_EXTERN __declspec(dllimport)
#    endif
#  endif
#else
```
