### PR TITLE
Use ssize_t declared by toolchain when available

### DIFF
--- a/trantor/net/EventLoop.cc
+++ b/trantor/net/EventLoop.cc
@@ -28,7 +28,9 @@
 #include <windows.h>
 #include <io.h>
 #include <synchapi.h>
+#ifndef _SSIZE_T_DEFINED
 using ssize_t = long long;
+#endif
 #else
 #include <poll.h>
 #endif

--- a/trantor/utils/MsgBuffer.h
+++ b/trantor/utils/MsgBuffer.h
@@ -22,7 +22,7 @@
 #include <assert.h>
 #include <string.h>
 #include <cstdint>
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_SSIZE_T_DEFINED)
 using ssize_t = std::intptr_t;
 #endif
 


### PR DESCRIPTION
crtdefs.h already declares ssize_t.