### PR TITLE
Enable Botan3 TLS provider on Windows

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pip install conan
           conan profile detect --force
-          conan install .. --output-folder=. --build=missing --settings=build_type=${{matrix.build-type}} --settings=compiler="msvc" --settings=compiler.version=193 
+          conan install .. --output-folder=. --build=missing --settings=build_type=${{matrix.build-type}} --settings=compiler="msvc"
 
       - name: Create Build Environment & Configure Cmake
         shell: bash

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -16,9 +16,7 @@ jobs:
         link: [ 'STATIC', 'SHARED' ]
         # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
         build-type: ['Debug', 'Release']
-        # TODO: conan botan is v2, v2 support is removed
-        # tls-provider: ['', 'openssl', 'botan']
-        tls-provider: ['', 'openssl']
+        tls-provider: ['', 'openssl', 'botan']
 
     steps:
       - name: Checkout Trantor source code
@@ -38,6 +36,9 @@ jobs:
           pip install conan
           conan profile detect --force
           conan install .. --output-folder=. --build=missing --settings=build_type=${{matrix.build-type}} --settings=compiler="msvc"
+          if [[ ${{ matrix.tls-provider }} != "" ]]; then
+            conan install ${{matrix.tls-provider}} --output-folder=. --build=missing --settings=build_type=${{matrix.build-type}} --settings=compiler="msvc"
+          fi
 
       - name: Create Build Environment & Configure Cmake
         shell: bash

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 gtest/1.10.0
-openssl/1.1.1t
+openssl/3.2.2
 #c-ares/1.17.1
 spdlog/1.12.0
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,5 @@
 [requires]
 gtest/1.10.0
-openssl/1.1.1t
 #c-ares/1.17.1
 spdlog/1.12.0
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 gtest/1.10.0
-openssl/3.2.2
+openssl/1.1.1t
 #c-ares/1.17.1
 spdlog/1.12.0
 


### PR DESCRIPTION
Currently Botan is disabled for Linux (no package available for Botan 3) and MacOS (compiler issues). This PR enables Botan 3 for Windows so it is tested