### PR TITLE
Feature: TcpServer hot reload SSL file

### DIFF
--- a/trantor/net/TcpServer.h
+++ b/trantor/net/TcpServer.h
@@ -260,6 +260,17 @@ class TRANTOR_EXPORT TcpServer : NonCopyable
         sslContextPtr_ = newSSLContext(*policyPtr_, true);
     }
 
+    /**
+     * @brief Reload the SSL context.
+     * @note Call this function when the certificate or private key is updated. 
+     * The server will reload the SSL context and use the new certificate and private key.
+     * new connections will use the new SSL context.
+     */
+    void reloadSSL(){
+        if (policyPtr_) {
+            sslContextPtr_ = newSSLContext(*policyPtr_, true);
+        }
+    }
   private:
     void handleCloseInLoop(const TcpConnectionPtr &connectionPtr);
     void newConnection(int fd, const InetAddress &peer);


### PR DESCRIPTION
While the TcpServer is running, reload the SSL from the file. New connections will use the new SSL, while existing connections will remain unchanged.