### PR TITLE
Feature: TcpServer hot reload SSL file

### DIFF
--- a/trantor/net/TcpServer.cc
+++ b/trantor/net/TcpServer.cc
@@ -239,15 +239,15 @@ void TcpServer::reloadSSL()
 {
     if (loop_->isInLoopThread())
     {
-        if (policyPtr_) 
+        if (policyPtr_)
         {
             sslContextPtr_ = newSSLContext(*policyPtr_, true);
         }
-    } 
-    else 
+    }
+    else
     {
         loop_->queueInLoop([this]() {
-            if (policyPtr_) 
+            if (policyPtr_)
             {
                 sslContextPtr_ = newSSLContext(*policyPtr_, true);
             }

--- a/trantor/net/TcpServer.cc
+++ b/trantor/net/TcpServer.cc
@@ -234,3 +234,23 @@ void TcpServer::enableSSL(
         .setValidate(caPath.empty() ? false : true);
     sslContextPtr_ = newSSLContext(*policyPtr_, true);
 }
+
+void TcpServer::reloadSSL()
+{
+    if (loop_->isInLoopThread())
+    {
+        if (policyPtr_) 
+        {
+            sslContextPtr_ = newSSLContext(*policyPtr_, true);
+        }
+    } 
+    else 
+    {
+        loop_->queueInLoop([this]() {
+            if (policyPtr_) 
+            {
+                sslContextPtr_ = newSSLContext(*policyPtr_, true);
+            }
+        });
+    }
+}

--- a/trantor/net/TcpServer.h
+++ b/trantor/net/TcpServer.h
@@ -262,9 +262,9 @@ class TRANTOR_EXPORT TcpServer : NonCopyable
 
     /**
      * @brief Reload the SSL context.
-     * @note Call this function when the certificate or private key is updated. 
-     * The server will reload the SSL context and use the new certificate and private key.
-     * new connections will use the new SSL context.
+     * @note Call this function when the certificate or private key is updated.
+     * The server will reload the SSL context and use the new certificate and
+     * private key. new connections will use the new SSL context.
      */
     void reloadSSL();
 

--- a/trantor/net/TcpServer.h
+++ b/trantor/net/TcpServer.h
@@ -260,6 +260,14 @@ class TRANTOR_EXPORT TcpServer : NonCopyable
         sslContextPtr_ = newSSLContext(*policyPtr_, true);
     }
 
+    /**
+     * @brief Reload the SSL context.
+     * @note Call this function when the certificate or private key is updated. 
+     * The server will reload the SSL context and use the new certificate and private key.
+     * new connections will use the new SSL context.
+     */
+    void reloadSSL();
+
   private:
     void handleCloseInLoop(const TcpConnectionPtr &connectionPtr);
     void newConnection(int fd, const InetAddress &peer);


### PR DESCRIPTION
While the TcpServer is running, reload the SSL from the file. New connections will use the new SSL, while existing connections will remain unchanged.