### PR TITLE
Free leaked memory in ares resolver

### DIFF
--- a/trantor/net/inner/AresResolver.cc
+++ b/trantor/net/inner/AresResolver.cc
@@ -202,6 +202,7 @@ void AresResolver::onQueryResult(int status,
                 // TODO: Handle unknown family?
             }
         }
+        ares_freeaddrinfo(result);
     }
     if (inets_ptr->empty())
     {
@@ -218,7 +219,6 @@ void AresResolver::onQueryResult(int status,
         addrItem.first = inets_ptr;
         addrItem.second = trantor::Date::date();
     }
-    ares_freeaddrinfo(result);
     callback(*inets_ptr);
 }
 

--- a/trantor/net/inner/AresResolver.cc
+++ b/trantor/net/inner/AresResolver.cc
@@ -218,6 +218,7 @@ void AresResolver::onQueryResult(int status,
         addrItem.first = inets_ptr;
         addrItem.second = trantor::Date::date();
     }
+    ares_freeaddrinfo(result);
     callback(*inets_ptr);
 }
 


### PR DESCRIPTION
Just added `ares_freeaddrinfo` after using the resolve results.