### PR TITLE
Fixed possibility to pass nullptr to memcpy

### DIFF
--- a/trantor/utils/LogStream.h
+++ b/trantor/utils/LogStream.h
@@ -45,7 +45,7 @@ class TRANTOR_EXPORT FixedBuffer : NonCopyable
 
     bool append(const char * /*restrict*/ buf, size_t len)
     {
-        if ((size_t)(avail()) > len)
+        if ((size_t)(avail()) > len && buf)
         {
             memcpy(cur_, buf, len);
             cur_ += len;


### PR DESCRIPTION
Undefined behavior sanitizer (UBSAN) finds an undefined behavior in `LogStream.h`:

```
/builds/ZWJbGeiL/0/arenadata/development/adqmc/services/contrib/drogon/trantor/trantor/utils/LogStream.h:50:26: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /builds/ZWJbGeiL/0/arenadata/development/adqmc/services/contrib/drogon/trantor/trantor/utils/LogStream.h:50:26 
```

This PR adds a nullptr check to the `buf` pointer.

------
How to reproduce the bug:
```cpp
#include <trantor/utils/Logger.h>
#include <drogon/utils/Utilities.h> // inline LogStream &operator<<(LogStream &ls, const std::string_view &v)

// Compile the code with UBSAN
int main(int argc, char * argv[])
{
    std::string_view default_initialized_sv = std::string_view(); 
    LOG_DEBUG << default_initialized_sv;  // <-- leads to passing nullptr, 0 to the append function
}
```

Alternative solution:
Move these lines from Drogon to Trantor:
https://github.com/drogonframework/drogon/blob/47f8af7ca1601997b036652fc329b58384645200/lib/inc/drogon/utils/Utilities.h#L583-L595

With modification:
instead of
```cpp
ls.append(v.data(), v.length());
```

do:
```cpp
   if (!v.empty())
         ls.append(v.data(), v.length());
```

