### PR TITLE
Replace ipv4 inet_ntop with a handrolled function

### DIFF
--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -196,16 +196,39 @@ bool InetAddress::isLoopbackIp() const
     return false;
 }
 
+static void byteToChars(std::string::iterator& dst, unsigned char byte)
+{
+    *dst = byte / 100 + '0';
+    dst += byte >= 100;
+    *dst = byte % 100 / 10 + '0';
+    dst += byte >= 10;
+    *dst = byte % 10 + '0';
+    ++dst;
+}
+
+static constexpr char stringInitBuffer[15]{};
+std::string iptos(unsigned inet_addr)
+{
+    // Initialize with a static buffer to force the constructor of string to get fully inlined
+    std::string out(stringInitBuffer, 15);
+    std::string::iterator dst = out.begin();
+    byteToChars(dst, inet_addr >> 0 & 0xff);
+    *(dst++) = '.';
+    byteToChars(dst, inet_addr >> 8 & 0xff);
+    *(dst++) = '.';
+    byteToChars(dst, inet_addr >> 16 & 0xff);
+    *(dst++) = '.';
+    byteToChars(dst, inet_addr >> 24 & 0xff);
+    out.erase(dst, out.end());
+    return out;
+}
+
 std::string InetAddress::toIp() const
 {
-    char buf[64];
+    char buf[INET6_ADDRSTRLEN]{};
     if (addr_.sin_family == AF_INET)
     {
-#if defined _WIN32
-        ::inet_ntop(AF_INET, (PVOID)&addr_.sin_addr, buf, sizeof(buf));
-#else
-        ::inet_ntop(AF_INET, &addr_.sin_addr, buf, sizeof(buf));
-#endif
+        return iptos(addr_.sin_addr.s_addr);
     }
     else if (addr_.sin_family == AF_INET6)
     {


### PR DESCRIPTION
`toIp` is a surprisingly hot function when used in Drogon, accounting for a grand 6% of total runtime when I measured it during my stress tests.
I've tried to make the new function as efficient and consistent as possible, avoiding allocations by abusing the small string optimization. The longest IPv4 address has a total of 15 characters which is just enough to fit in a small libstdc++ string.
To abuse this, I preallocated the string and performed the conversion inside of it with a helper function that does work unconditionally, which achieves really good throughput and low run to run variance.
This speeds up IP to string conversion by about 10x
```
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
iptos            9.22 ns         9.22 ns     75759258
ntop             93.3 ns         93.3 ns      7407629
```