### PR TITLE
Fix Date::fromDbStringLocal() when YYYY-MM-DD is given (modify issue #75)

### DIFF
--- a/trantor/unittests/DateUnittest.cc
+++ b/trantor/unittests/DateUnittest.cc
@@ -110,7 +110,7 @@ TEST(Date, DatabaseStringTest)
     dbString = "1970-01-01";
     dbDateGMT = trantor::Date::fromDbString(dbString);
     auto epoch = dbDateGMT.microSecondsSinceEpoch();
-    EXPECT_EQ(epoch,0);
+    EXPECT_EQ(epoch, 0);
 }
 int main(int argc, char **argv)
 {

--- a/trantor/unittests/DateUnittest.cc
+++ b/trantor/unittests/DateUnittest.cc
@@ -106,6 +106,11 @@ TEST(Date, DatabaseStringTest)
     dbDate = trantor::Date::fromDbString(dbString);
     us = (dbDate.microSecondsSinceEpoch() % 1000000);
     EXPECT_EQ(us, 3);
+
+    dbString = "1970-01-01";
+    dbDateGMT = trantor::Date::fromDbString(dbString);
+    auto epoch = dbDateGMT.microSecondsSinceEpoch();
+    EXPECT_EQ(epoch,0);
 }
 int main(int argc, char **argv)
 {

--- a/trantor/utils/Date.cc
+++ b/trantor/utils/Date.cc
@@ -285,7 +285,8 @@ Date Date::fromDbStringLocal(const std::string &datetime)
                  second = {0}, microSecond = {0};
     std::vector<std::string> &&v = splitString(datetime, " ");
 
-    if(v.size()==0){
+    if (v.size() == 0)
+    {
         throw std::invalid_argument("Invalid date string: " + datetime);
     }
     const std::vector<std::string> date = splitString(v[0], "-");
@@ -312,7 +313,8 @@ Date Date::fromDbStringLocal(const std::string &datetime)
     if (v.size() == 2)
     {
         // Format YYYY-MM-DD HH:MM:SS[.UUUUUU] is given
-        try{
+        try
+        {
             year = std::stol(date[0]);
             month = std::stol(date[1]);
             day = std::stol(date[2]);
@@ -336,12 +338,14 @@ Date Date::fromDbStringLocal(const std::string &datetime)
                     microSecond = std::stol(seconds[1]);
                 }
             }
-        }catch(...){
+        }
+        catch (...)
+        {
             throw std::invalid_argument("Invalid date string: " + datetime);
         }
         return Date(year, month, day, hour, minute, second, microSecond);
     }
-    
+
     throw std::invalid_argument("Invalid date string: " + datetime);
 }
 

--- a/trantor/utils/Date.cc
+++ b/trantor/utils/Date.cc
@@ -284,12 +284,35 @@ Date Date::fromDbStringLocal(const std::string &datetime)
     unsigned int year = {0}, month = {0}, day = {0}, hour = {0}, minute = {0},
                  second = {0}, microSecond = {0};
     std::vector<std::string> &&v = splitString(datetime, " ");
-    if (2 == v.size())
+
+    if(v.size()==0){
+        throw std::invalid_argument("Invalid date string: " + datetime);
+    }
+    const std::vector<std::string> date = splitString(v[0], "-");
+    if (date.size() != 3)
     {
-        // date
-        std::vector<std::string> date = splitString(v[0], "-");
-        if (3 == date.size())
+        throw std::invalid_argument("Invalid date string: " + datetime);
+    }
+    if (v.size() == 1)
+    {
+        // Fromat YYYY-MM-DD is given
+        try
         {
+            year = std::stol(date[0]);
+            month = std::stol(date[1]);
+            day = std::stol(date[2]);
+        }
+        catch (...)
+        {
+            throw std::invalid_argument("Invalid date string: " + datetime);
+        }
+        return Date(year, month, day, hour, minute, second, microSecond);
+    }
+
+    if (v.size() == 2)
+    {
+        // Format YYYY-MM-DD HH:MM:SS[.UUUUUU] is given
+        try{
             year = std::stol(date[0]);
             month = std::stol(date[1]);
             day = std::stol(date[2]);
@@ -313,10 +336,15 @@ Date Date::fromDbStringLocal(const std::string &datetime)
                     microSecond = std::stol(seconds[1]);
                 }
             }
+        }catch(...){
+            throw std::invalid_argument("Invalid date string: " + datetime);
         }
+        return Date(year, month, day, hour, minute, second, microSecond);
     }
-    return trantor::Date(year, month, day, hour, minute, second, microSecond);
+    
+    throw std::invalid_argument("Invalid date string: " + datetime);
 }
+
 Date Date::fromDbString(const std::string &datetime)
 {
     return fromDbStringLocal(datetime).after(


### PR DESCRIPTION
# abstract

I fixed `Date::fromDbStringLocal()` bug ,which is mentioned [here](https://github.com/an-tao/trantor/issues/375)

# Cause of the bug

in `Date::fromDbStringLocal(const std::string &datetime)`  
function `std::vector<std::string> &&v = splitString(datetime, " ");`  is used.

when  argument datetime format is `YYYY-MM-DD`, then `v.size()` equals 1  and program  doesn't pass through `if (v.size() == 2)`.

# implementation

1. add  unit test when format `YYYY-MM-DD` is given.
2. modify `Date::fromDbStringLocal()` function to adapt format `YYYY-MM-DD`. in this case, `v.size()` is 1

