### PR TITLE
Fix building error for -Werror=unused-value

### DIFF
--- a/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
+++ b/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
@@ -774,7 +774,7 @@ struct OpenSSLProvider : public TLSProvider, public NonCopyable
         {
             appendToWriteBuffer((char *)data + n, len - n);
         }
-        BIO_reset(wbio_);
+        (void)BIO_reset(wbio_);
         if (n < 0)
             return -1;
         return len;


### PR DESCRIPTION
Compiling trantor in Buildroot raises the following error:

In file included from output/host/include/openssl/ssl.h:30,
                 from output/build/host-drogon-v1.9.11/trantor/trantor/net/inner/tlsprovider/OpenSSLProvider.cc:6:
build/host-drogon-v1.9.11/trantor/trantor/net/inner/tlsprovider/OpenSSLProvider.cc: In member function ‘ssize_t OpenSSLProvider::sendTLSData()’: output/host/include/openssl/bio.h:629:34: error: value computed is not used [-Werror=unused-value]
  629 | # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
output/build/host-drogon-v1.9.11/trantor/trantor/net/inner/tlsprovider/OpenSSLProvider.cc:777:9: note: in expansion of macro ‘BIO_reset’
  777 |         BIO_reset(wbio_);
      |         ^~~~~~~~~