### PR TITLE
Fix range sendFile() for MinGW

### DIFF
--- a/trantor/net/inner/TcpConnectionImpl.cc
+++ b/trantor/net/inner/TcpConnectionImpl.cc
@@ -554,7 +554,7 @@ void TcpConnectionImpl::sendFile(const char *fileName,
 {
     assert(fileName);
 #ifdef _WIN32
-    sendFile(utils::toNativePath(fileName).c_str(), offset, length);
+    sendFile(utils::toWidePath(fileName).c_str(), offset, length);
 #else   // _WIN32
     auto fileNode = BufferNode::newFileBufferNode(fileName, offset, length);
 


### PR DESCRIPTION
Since toNativePath() returns std::string for MinGW win32, we end up in an infinite loop.