### PR TITLE
Added automatic SSL

### DIFF
--- a/trantor/net/TcpConnection.h
+++ b/trantor/net/TcpConnection.h
@@ -45,7 +45,7 @@ class TRANTOR_EXPORT TcpConnection
     friend class TcpClient;
 
     TcpConnection() = default;
-    virtual ~TcpConnection(){};
+    virtual ~TcpConnection() {};
 
     /**
      * @brief Send some data to the peer.
@@ -366,6 +366,8 @@ class TRANTOR_EXPORT TcpConnection
     virtual void enableKickingOff(
         size_t timeout,
         const std::shared_ptr<TimingWheel> &timingWheel) = 0;
+
+    virtual void forwardToTLSBuffer(MsgBuffer *buffer) = 0;
 
   protected:
     // callbacks

--- a/trantor/net/TcpConnection.h
+++ b/trantor/net/TcpConnection.h
@@ -45,7 +45,7 @@ class TRANTOR_EXPORT TcpConnection
     friend class TcpClient;
 
     TcpConnection() = default;
-    virtual ~TcpConnection() {};
+    virtual ~TcpConnection(){};
 
     /**
      * @brief Send some data to the peer.

--- a/trantor/net/inner/TcpConnectionImpl.h
+++ b/trantor/net/inner/TcpConnectionImpl.h
@@ -203,6 +203,12 @@ class TcpConnectionImpl : public TcpConnection,
         timingWheel->insertEntry(timeout, entry);
     }
 
+    void forwardToTLSBuffer(MsgBuffer *buffer) override
+    {
+        if (tlsProviderPtr_)
+            tlsProviderPtr_->recvData(buffer);
+    }
+
   private:
     /// Internal use only.
 

--- a/trantor/tests/AutomaticSSLClientTest.cc
+++ b/trantor/tests/AutomaticSSLClientTest.cc
@@ -1,0 +1,54 @@
+#include <trantor/net/TcpClient.h>
+#include <trantor/utils/Logger.h>
+#include <trantor/net/EventLoopThread.h>
+#include <string>
+#include <iostream>
+#include <atomic>
+using namespace trantor;
+#define USE_IPV6 0
+int main()
+{
+    trantor::Logger::setLogLevel(trantor::Logger::kDebug);
+    LOG_DEBUG << "TcpClient class test!";
+    EventLoop loop;
+#if USE_IPV6
+    InetAddress serverAddr("::1", 8888, true);
+#else
+    InetAddress serverAddr("127.0.0.1", 8888);
+#endif
+    std::shared_ptr<trantor::TcpClient> client[10];
+    std::atomic_int connCount;
+    connCount = 1;
+    for (int i = 0; i < 1; ++i)
+    {
+        client[i] = std::make_shared<trantor::TcpClient>(&loop,
+                                                         serverAddr,
+                                                         "tcpclienttest");
+        auto policy = TLSPolicy::defaultClientPolicy();
+        policy->setValidate(false);
+        client[i]->enableSSL(std::move(policy));
+        client[i]->setConnectionCallback(
+            [i, &loop, &connCount](const TcpConnectionPtr &conn) {
+                if (conn->connected())
+                {
+                    LOG_DEBUG << i << " connected";
+                    conn->send("Hello");
+                }
+                else
+                {
+                    LOG_DEBUG << i << " disconnected";
+                    --connCount;
+                    if (connCount == 0)
+                        loop.quit();
+                }
+            });
+        client[i]->setMessageCallback(
+            [](const TcpConnectionPtr &conn, MsgBuffer *buf) {
+                auto msg = std::string(buf->peek(), buf->readableBytes());
+                LOG_INFO << msg;
+                buf->retrieveAll();
+            });
+        client[i]->connect();
+    }
+    loop.loop();
+}

--- a/trantor/tests/AutomaticSSLServerTest.cc
+++ b/trantor/tests/AutomaticSSLServerTest.cc
@@ -1,0 +1,63 @@
+#include <trantor/net/TcpServer.h>
+#include <trantor/utils/Logger.h>
+#include <trantor/net/EventLoopThread.h>
+#include <string>
+#include <iostream>
+using namespace trantor;
+#define USE_IPV6 0
+
+bool has_ssl(MsgBuffer *buffer)
+{
+    if (buffer->readableBytes() < 3)
+        return false;
+    const char *data = buffer->peek();
+    unsigned char byte1 = static_cast<unsigned char>(data[0]);
+    unsigned char byte2 = static_cast<unsigned char>(data[1]);
+    unsigned char byte3 = static_cast<unsigned char>(data[2]);
+    return (byte1 == 0x16) && (byte2 == 0x03) && (byte3 == 0x01);
+}
+
+int main()
+{
+    LOG_DEBUG << "test start";
+    Logger::setLogLevel(Logger::kDebug);
+    EventLoopThread loopThread;
+    loopThread.run();
+#if USE_IPV6
+    InetAddress addr(8888, true, true);
+#else
+    InetAddress addr(8888);
+#endif
+    TcpServer server(loopThread.getLoop(), addr, "test");
+    // auto ctx = newSSLServerContext("server.pem", "server.pem", {});
+    LOG_INFO << "start";
+    server.setRecvMessageCallback(
+        [](const TcpConnectionPtr &connectionPtr, MsgBuffer *buffer) {
+            if (has_ssl(buffer))
+            {
+                LOG_DEBUG << "SSL data received";
+                auto policy =
+                    TLSPolicy::defaultServerPolicy("server.crt", "server.key");
+                connectionPtr->startEncryption(policy, true);
+                connectionPtr->forwardToTLSBuffer(buffer);
+                return;
+            }
+            LOG_DEBUG << std::string{buffer->peek(), buffer->readableBytes()};
+            connectionPtr->send(*buffer);
+            buffer->retrieveAll();
+            connectionPtr->shutdown();
+        });
+    server.setConnectionCallback([](const TcpConnectionPtr &connPtr) {
+        if (connPtr->connected())
+        {
+            LOG_DEBUG << "New connection";
+        }
+        else if (connPtr->disconnected())
+        {
+            LOG_DEBUG << "connection disconnected";
+        }
+    });
+    server.setIoLoopNum(3);
+    server.start();
+    loopThread.wait();
+}

--- a/trantor/tests/CMakeLists.txt
+++ b/trantor/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(logger_macro_test LoggerMacroTest.cc)
 add_executable(delayed_ssl_server_test DelayedSSLServerTest.cc)
 add_executable(delayed_ssl_client_test DelayedSSLClientTest.cc)
 add_executable(tcp_asyncstream_server_test TcpAsyncStreamServerTest.cc)
+add_executable(automatic_ssl_server_test AutomaticSSLServerTest.cc)
+add_executable(automatic_ssl_client_test AutomaticSSLClientTest.cc)
 set(targets_list
     ssl_server_test
     ssl_client_test
@@ -49,6 +51,8 @@ set(targets_list
     delayed_ssl_server_test
     delayed_ssl_client_test
     tcp_asyncstream_server_test
+    automatic_ssl_server_test
+    automatic_ssl_client_test
 )
 
 if(HAVE_SPDLOG)


### PR DESCRIPTION
Hi!

I used **trantor** as the main networking library in my project.

While working on it, I had a strong need to support **automatic SSL/TLS connections**. I know that trantor already supports **delayed SSL**, where the client first sends a signal message (for example, `ssl-hello`) indicating that it is going to start an encrypted connection, and only then the TLS handshake begins. However, in the project I’m working on, the client can start an SSL/TLS encrypted connection **immediately**, without any signal message or warning, and it was critically important for us to support this behavior.

To achieve this, I implemented a small helper function called **`forwardToTLSBuffer`**. Its purpose is to move the data currently stored in the buffer of the _existing plaintext connection_ into the buffer of the _new TLS connection_.

If the server receives data on a plaintext connection and that data appears to start with an **SSL/TLS handshake**, the server detects it and upgrades the connection to TLS, passing the already-received handshake bytes using `forwardToTLSBuffer`.

To demonstrate how it works, I added two tests: **`AutomaticSSLClientTest.cc`** and **`AutomaticSSLServerTest.cc`** (following the structure of **`DelayedSSLClientTest.cc`** and **`DelayedSSLServerTest.cc`**).

With this change, trantor can be used to build a “smart server” that dynamically adapts to the client’s connection type (plain TCP or TLS) on the fly.