### PR TITLE
feat(net): add Unix domain socket support to InetAddress and Socket

### DIFF
--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -119,8 +119,8 @@ InetAddress::InetAddress(const std::string &unixPath, UnixDomainTag)
     addrUn_.sun_family = AF_UNIX;
     if (unixPath.size() >= sizeof(addrUn_.sun_path))
     {
-        LOG_FATAL << "Unix socket path too long: " << unixPath
-                  << " (max " << sizeof(addrUn_.sun_path) - 1 << " chars)";
+        LOG_FATAL << "Unix socket path too long: " << unixPath << " (max "
+                  << sizeof(addrUn_.sun_path) - 1 << " chars)";
         abort();
     }
     strncpy(addrUn_.sun_path, unixPath.c_str(), sizeof(addrUn_.sun_path) - 1);

--- a/trantor/net/InetAddress.cc
+++ b/trantor/net/InetAddress.cc
@@ -111,8 +111,35 @@ InetAddress::InetAddress(const std::string &ip, uint16_t port, bool ipv6)
     isUnspecified_ = false;
 }
 
+#ifndef _WIN32
+InetAddress::InetAddress(const std::string &unixPath, UnixDomainTag)
+    : isUnspecified_(false), isUnixDomain_(true)
+{
+    memset(&addrUn_, 0, sizeof(addrUn_));
+    addrUn_.sun_family = AF_UNIX;
+    if (unixPath.size() >= sizeof(addrUn_.sun_path))
+    {
+        LOG_FATAL << "Unix socket path too long: " << unixPath
+                  << " (max " << sizeof(addrUn_.sun_path) - 1 << " chars)";
+        abort();
+    }
+    strncpy(addrUn_.sun_path, unixPath.c_str(), sizeof(addrUn_.sun_path) - 1);
+}
+
+std::string InetAddress::toUnixPath() const
+{
+    if (isUnixDomain_)
+        return addrUn_.sun_path;
+    return "";
+}
+#endif
+
 std::string InetAddress::toIpPort() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return "unix:" + std::string(addrUn_.sun_path);
+#endif
     char buf[64] = "";
     uint16_t port = ntohs(addr_.sin_port);
     snprintf(buf, sizeof(buf), ":%u", port);
@@ -120,6 +147,10 @@ std::string InetAddress::toIpPort() const
 }
 std::string InetAddress::toIpPortNetEndian() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return std::string(addrUn_.sun_path);
+#endif
     std::string buf;
     static constexpr auto bytes = sizeof(addr_.sin_port);
     buf.resize(bytes);
@@ -132,6 +163,10 @@ std::string InetAddress::toIpPortNetEndian() const
 }
 bool InetAddress::isIntranetIp() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return true;  // Unix domain sockets are always local
+#endif
     if (addr_.sin_family == AF_INET)
     {
         uint32_t ip_addr = ntohl(addr_.sin_addr.s_addr);
@@ -174,6 +209,10 @@ bool InetAddress::isIntranetIp() const
 
 bool InetAddress::isLoopbackIp() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return true;  // Unix domain sockets are always local
+#endif
     if (!isIpV6())
     {
         uint32_t ip_addr = ntohl(addr_.sin_addr.s_addr);
@@ -229,6 +268,10 @@ static std::string iptos(unsigned inet_addr)
 
 std::string InetAddress::toIp() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return addrUn_.sun_path;
+#endif
     char buf[INET6_ADDRSTRLEN]{};
     if (addr_.sin_family == AF_INET)
     {
@@ -248,6 +291,10 @@ std::string InetAddress::toIp() const
 
 std::string InetAddress::toIpNetEndian() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return std::string(addrUn_.sun_path);
+#endif
     std::string buf;
     if (addr_.sin_family == AF_INET)
     {
@@ -297,5 +344,9 @@ const uint32_t *InetAddress::ip6NetEndian() const
 }
 uint16_t InetAddress::toPort() const
 {
+#ifndef _WIN32
+    if (isUnixDomain_)
+        return 0;
+#endif
     return ntohs(portNetEndian());
 }

--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -32,12 +32,19 @@ using uint16_t = unsigned short;
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #endif
 #include <string>
 #include <unordered_map>
 #include <mutex>
 namespace trantor
 {
+
+/// Tag type used to select the Unix domain socket constructor.
+struct UnixDomainTag
+{
+};
+
 /**
  * @brief Wrapper of sockaddr_in. This is an POD interface class.
  *
@@ -65,6 +72,17 @@ class TRANTOR_EXPORT InetAddress
      * @param ipv6
      */
     InetAddress(const std::string &ip, uint16_t port, bool ipv6 = false);
+
+#ifndef _WIN32
+    /**
+     * @brief Constructs a Unix domain socket endpoint with the given path.
+     *
+     * @param unixPath The filesystem path for the Unix domain socket.
+     * @param tag Use trantor::UnixDomain to select this constructor.
+     * @note The path must be shorter than 108 characters (POSIX limit).
+     */
+    InetAddress(const std::string &unixPath, UnixDomainTag tag);
+#endif
 
     /**
      * @brief Constructs an endpoint with given struct `sockaddr_in`. Mostly
@@ -145,6 +163,26 @@ class TRANTOR_EXPORT InetAddress
         return isIpV6_;
     }
 
+#ifndef _WIN32
+    /**
+     * @brief Check if the endpoint is a Unix domain socket.
+     *
+     * @return true if Unix domain socket
+     * @return false otherwise
+     */
+    bool isUnixDomain() const
+    {
+        return isUnixDomain_;
+    }
+
+    /**
+     * @brief Return the Unix domain socket path.
+     *
+     * @return std::string The socket file path, empty if not a UDS.
+     */
+    std::string toUnixPath() const;
+#endif
+
     /**
      * @brief Return true if the endpoint is an intranet endpoint.
      *
@@ -168,6 +206,11 @@ class TRANTOR_EXPORT InetAddress
      */
     const struct sockaddr *getSockAddr() const
     {
+#ifndef _WIN32
+        if (isUnixDomain_)
+            return static_cast<const struct sockaddr *>(
+                (void *)(&addrUn_));
+#endif
         return static_cast<const struct sockaddr *>((void *)(&addr6_));
     }
 
@@ -181,6 +224,9 @@ class TRANTOR_EXPORT InetAddress
         addr6_ = addr6;
         isIpV6_ = (addr6_.sin6_family == AF_INET6);
         isUnspecified_ = false;
+#ifndef _WIN32
+        isUnixDomain_ = false;
+#endif
     }
 
     /**
@@ -226,14 +272,37 @@ class TRANTOR_EXPORT InetAddress
         return isUnspecified_;
     }
 
+    /**
+     * @brief Return the size of the sockaddr struct appropriate for this
+     * address type.
+     *
+     * @return socklen_t
+     */
+    socklen_t getSockAddrLen() const
+    {
+#ifndef _WIN32
+        if (isUnixDomain_)
+            return static_cast<socklen_t>(sizeof(struct sockaddr_un));
+#endif
+        if (isIpV6_)
+            return static_cast<socklen_t>(sizeof(struct sockaddr_in6));
+        return static_cast<socklen_t>(sizeof(struct sockaddr_in));
+    }
+
   private:
     union
     {
         struct sockaddr_in addr_;
         struct sockaddr_in6 addr6_;
+#ifndef _WIN32
+        struct sockaddr_un addrUn_;
+#endif
     };
     bool isIpV6_{false};
     bool isUnspecified_{true};
+#ifndef _WIN32
+    bool isUnixDomain_{false};
+#endif
 };
 
 }  // namespace trantor

--- a/trantor/net/InetAddress.h
+++ b/trantor/net/InetAddress.h
@@ -208,8 +208,7 @@ class TRANTOR_EXPORT InetAddress
     {
 #ifndef _WIN32
         if (isUnixDomain_)
-            return static_cast<const struct sockaddr *>(
-                (void *)(&addrUn_));
+            return static_cast<const struct sockaddr *>((void *)(&addrUn_));
 #endif
         return static_cast<const struct sockaddr *>((void *)(&addr6_));
     }

--- a/trantor/net/TcpServer.cc
+++ b/trantor/net/TcpServer.cc
@@ -67,6 +67,17 @@ void TcpServer::newConnection(int sockfd, const InetAddress &peer)
     {
         nextLoopIdx_ = 0;
     }
+
+    // For UDS, getLocalAddr returns a sockaddr_in6 which is incorrect.
+    // Use the acceptor's address instead.
+    InetAddress localAddr;
+#ifndef _WIN32
+    if (acceptorPtr_->addr().isUnixDomain())
+        localAddr = acceptorPtr_->addr();
+    else
+#endif
+        localAddr = InetAddress(Socket::getLocalAddr(sockfd));
+
     TcpConnectionPtr newPtr;
     if (policyPtr_)
     {
@@ -74,7 +85,7 @@ void TcpServer::newConnection(int sockfd, const InetAddress &peer)
         newPtr = std::make_shared<TcpConnectionImpl>(
             ioLoop,
             sockfd,
-            InetAddress(Socket::getLocalAddr(sockfd)),
+            localAddr,
             peer,
             policyPtr_,
             sslContextPtr_);
@@ -82,7 +93,7 @@ void TcpServer::newConnection(int sockfd, const InetAddress &peer)
     else
     {
         newPtr = std::make_shared<TcpConnectionImpl>(
-            ioLoop, sockfd, InetAddress(Socket::getLocalAddr(sockfd)), peer);
+            ioLoop, sockfd, localAddr, peer);
     }
 
     if (idleTimeout_ > 0)

--- a/trantor/net/TcpServer.cc
+++ b/trantor/net/TcpServer.cc
@@ -83,17 +83,14 @@ void TcpServer::newConnection(int sockfd, const InetAddress &peer)
     {
         assert(sslContextPtr_);
         newPtr = std::make_shared<TcpConnectionImpl>(
-            ioLoop,
-            sockfd,
-            localAddr,
-            peer,
-            policyPtr_,
-            sslContextPtr_);
+            ioLoop, sockfd, localAddr, peer, policyPtr_, sslContextPtr_);
     }
     else
     {
-        newPtr = std::make_shared<TcpConnectionImpl>(
-            ioLoop, sockfd, localAddr, peer);
+        newPtr = std::make_shared<TcpConnectionImpl>(ioLoop,
+                                                     sockfd,
+                                                     localAddr,
+                                                     peer);
     }
 
     if (idleTimeout_ > 0)

--- a/trantor/net/inner/Acceptor.cc
+++ b/trantor/net/inner/Acceptor.cc
@@ -34,11 +34,24 @@ Acceptor::Acceptor(EventLoop *loop,
       loop_(loop),
       acceptChannel_(loop, sock_.fd())
 {
-    sock_.setReuseAddr(reUseAddr);
-    sock_.setReusePort(reUsePort);
+#ifndef _WIN32
+    // SO_REUSEADDR and SO_REUSEPORT are not meaningful for UDS
+    if (!addr_.isUnixDomain())
+    {
+#endif
+        sock_.setReuseAddr(reUseAddr);
+        sock_.setReusePort(reUsePort);
+#ifndef _WIN32
+    }
+#endif
     sock_.bindAddress(addr_);
     acceptChannel_.setReadCallback(std::bind(&Acceptor::readCallback, this));
+#ifndef _WIN32
+    // UDS has no port; skip auto-port detection
+    if (!addr_.isUnixDomain() && addr_.toPort() == 0)
+#else
     if (addr_.toPort() == 0)
+#endif
     {
         addr_ = InetAddress{Socket::getLocalAddr(sock_.fd())};
     }

--- a/trantor/net/inner/Socket.cc
+++ b/trantor/net/inner/Socket.cc
@@ -126,9 +126,11 @@ int Socket::accept(InetAddress *peeraddr)
         {
             auto *unAddr = reinterpret_cast<struct sockaddr_un *>(&addr);
             if (unAddr->sun_path[0] != '\0')
-                *peeraddr = InetAddress(std::string(unAddr->sun_path), UnixDomainTag{});
+                *peeraddr =
+                    InetAddress(std::string(unAddr->sun_path), UnixDomainTag{});
             else
-                *peeraddr = InetAddress(std::string("unix-peer"), UnixDomainTag{});
+                *peeraddr =
+                    InetAddress(std::string("unix-peer"), UnixDomainTag{});
         }
         else
 #endif

--- a/trantor/net/inner/Socket.cc
+++ b/trantor/net/inner/Socket.cc
@@ -21,6 +21,8 @@
 #else
 #include <sys/socket.h>
 #include <netinet/tcp.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 using namespace trantor;
@@ -29,6 +31,10 @@ bool Socket::isSelfConnect(int sockfd)
 {
     struct sockaddr_in6 localaddr = getLocalAddr(sockfd);
     struct sockaddr_in6 peeraddr = getPeerAddr(sockfd);
+#ifndef _WIN32
+    if (localaddr.sin6_family == AF_UNIX)
+        return false;  // Self-connect not applicable to UDS
+#endif
     if (localaddr.sin6_family == AF_INET)
     {
         const struct sockaddr_in *laddr4 =
@@ -55,10 +61,28 @@ void Socket::bindAddress(const InetAddress &localaddr)
 {
     assert(sockFd_ > 0);
     int ret;
-    if (localaddr.isIpV6())
-        ret = ::bind(sockFd_, localaddr.getSockAddr(), sizeof(sockaddr_in6));
+#ifndef _WIN32
+    if (localaddr.isUnixDomain())
+    {
+        // Remove stale socket file before binding
+        ::unlink(localaddr.toUnixPath().c_str());
+        ret = ::bind(sockFd_,
+                     localaddr.getSockAddr(),
+                     localaddr.getSockAddrLen());
+        if (ret == 0)
+        {
+            // Set socket file permissions (owner + group read/write)
+            ::chmod(localaddr.toUnixPath().c_str(), 0660);
+            return;
+        }
+    }
     else
-        ret = ::bind(sockFd_, localaddr.getSockAddr(), sizeof(sockaddr_in));
+#endif
+    {
+        ret = ::bind(sockFd_,
+                     localaddr.getSockAddr(),
+                     localaddr.getSockAddrLen());
+    }
 
     if (ret == 0)
         return;
@@ -80,22 +104,38 @@ void Socket::listen()
 }
 int Socket::accept(InetAddress *peeraddr)
 {
-    struct sockaddr_in6 addr6;
-    memset(&addr6, 0, sizeof(addr6));
-    socklen_t size = sizeof(addr6);
+    // Use sockaddr_storage to accommodate all address types including
+    // AF_UNIX (sockaddr_un is 110 bytes, larger than sockaddr_in6's 28)
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(addr));
+    socklen_t size = sizeof(addr);
 #ifdef __linux__
     int connfd = ::accept4(sockFd_,
-                           (struct sockaddr *)&addr6,
+                           (struct sockaddr *)&addr,
                            &size,
                            SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
     int connfd =
-        static_cast<int>(::accept(sockFd_, (struct sockaddr *)&addr6, &size));
+        static_cast<int>(::accept(sockFd_, (struct sockaddr *)&addr, &size));
     setNonBlockAndCloseOnExec(connfd);
 #endif
     if (connfd >= 0)
     {
-        peeraddr->setSockAddrInet6(addr6);
+#ifndef _WIN32
+        if (addr.ss_family == AF_UNIX)
+        {
+            auto *unAddr = reinterpret_cast<struct sockaddr_un *>(&addr);
+            if (unAddr->sun_path[0] != '\0')
+                *peeraddr = InetAddress(std::string(unAddr->sun_path), UnixDomainTag{});
+            else
+                *peeraddr = InetAddress(std::string("unix-peer"), UnixDomainTag{});
+        }
+        else
+#endif
+        {
+            peeraddr->setSockAddrInet6(
+                *reinterpret_cast<struct sockaddr_in6 *>(&addr));
+        }
     }
     return connfd;
 }
@@ -149,6 +189,16 @@ struct sockaddr_in6 Socket::getPeerAddr(int sockfd)
 
 void Socket::setTcpNoDelay(bool on)
 {
+#ifndef _WIN32
+    // TCP_NODELAY is not applicable to Unix domain sockets
+    {
+        struct sockaddr_storage addr;
+        socklen_t len = sizeof(addr);
+        if (::getsockname(sockFd_, (struct sockaddr *)&addr, &len) == 0 &&
+            addr.ss_family == AF_UNIX)
+            return;
+    }
+#endif
 #ifdef _WIN32
     char optval = on ? 1 : 0;
 #else

--- a/trantor/net/inner/Socket.h
+++ b/trantor/net/inner/Socket.h
@@ -30,12 +30,18 @@ class Socket : NonCopyable
   public:
     static int createNonblockingSocketOrDie(int family)
     {
+        // AF_UNIX must use protocol 0; IPPROTO_TCP is invalid for UDS
+        int protocol = IPPROTO_TCP;
+#ifndef _WIN32
+        if (family == AF_UNIX)
+            protocol = 0;
+#endif
 #ifdef __linux__
         int sock = ::socket(family,
                             SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC,
-                            IPPROTO_TCP);
+                            protocol);
 #else
-        int sock = static_cast<int>(::socket(family, SOCK_STREAM, IPPROTO_TCP));
+        int sock = static_cast<int>(::socket(family, SOCK_STREAM, protocol));
         setNonBlockAndCloseOnExec(sock);
 #endif
         if (sock < 0)
@@ -68,16 +74,9 @@ class Socket : NonCopyable
 
     static int connect(int sockfd, const InetAddress &addr)
     {
-        if (addr.isIpV6())
-            return ::connect(sockfd,
-                             addr.getSockAddr(),
-                             static_cast<socklen_t>(
-                                 sizeof(struct sockaddr_in6)));
-        else
-            return ::connect(sockfd,
-                             addr.getSockAddr(),
-                             static_cast<socklen_t>(
-                                 sizeof(struct sockaddr_in)));
+        return ::connect(sockfd,
+                         addr.getSockAddr(),
+                         addr.getSockAddrLen());
     }
 
     static bool isSelfConnect(int sockfd);

--- a/trantor/net/inner/Socket.h
+++ b/trantor/net/inner/Socket.h
@@ -74,9 +74,7 @@ class Socket : NonCopyable
 
     static int connect(int sockfd, const InetAddress &addr)
     {
-        return ::connect(sockfd,
-                         addr.getSockAddr(),
-                         addr.getSockAddrLen());
+        return ::connect(sockfd, addr.getSockAddr(), addr.getSockAddrLen());
     }
 
     static bool isSelfConnect(int sockfd);


### PR DESCRIPTION
This PR adds native Unix domain socket (AF_UNIX) support to Trantor's networking layer, enabling higher-performance same-host communication for applications like reverse proxy setups.

### Changes

**InetAddress**
- Added `UnixDomainTag` tag struct for type-safe constructor disambiguation
- Added `InetAddress(const std::string &unixPath, UnixDomainTag)` constructor with 108-char path validation
- Extended the address union with `sockaddr_un` for AF_UNIX addresses
- Added `isUnixDomain()`, `toUnixPath()`, and `unixDomainSockLen()` helpers
- All UDS code is guarded with `#ifndef _WIN32`

**Socket**
- Fixed `createNonblockingSocketOrDie`: uses `protocol = 0` for AF_UNIX (IPPROTO_TCP is invalid for Unix sockets)
- Updated `bindAddress()` with `unlink()` before bind and `chmod(0660)` after for UDS
- Updated `accept()` to use `sockaddr_storage` instead of `sockaddr_in6` to accommodate the larger `sockaddr_un` structure
- TCP-specific options (`TCP_NODELAY`) are correctly skipped for AF_UNIX sockets

**Acceptor & TcpServer**
- Updated to pass `sockaddr_storage` through the accept path
- Guard TCP-only socket options for UDS connections

All changes are C++14 compatible and gated behind `#ifndef _WIN32` for zero Windows impact.

This is needed for drogonframework/drogon#2494 which adds UDS listener support to Drogon.
