### PR TITLE
Fix -Wunused-result error on std::future::get() with newer Clang

### DIFF
--- a/trantor/utils/TaskQueue.h
+++ b/trantor/utils/TaskQueue.h
@@ -49,7 +49,7 @@ class TaskQueue : public NonCopyable
             task();
             prom.set_value(1);
         });
-        fut.get();
+        (void)fut.get();
     };
     virtual ~TaskQueue()
     {


### PR DESCRIPTION
## Problem

Building with recent Clang (macOS 27 SDK / Xcode 27) fails when `-Werror` is enabled:

```
TaskQueue.h:52:9: error: ignoring return value of function declared with
'nodiscard' attribute [-Werror,-Wunused-result]
   52 |         fut.get();
```

`std::future::get()` is now annotated `[[nodiscard]]` in newer libc++, and trantor compiles with `-Wall -Wextra -Werror`.

## Fix

Add `(void)` cast to explicitly discard the return value, which is the conventional way to suppress this warning.

## Testing

- Built successfully with Apple Clang on macOS 27 (arm64) with `-Werror`.