### PR TITLE
Date::timezoneOffset return 1h with CEST (UTC+2) instead of 2 #401

### DIFF
--- a/trantor/unittests/DateUnittest.cc
+++ b/trantor/unittests/DateUnittest.cc
@@ -1,5 +1,6 @@
 #include <trantor/utils/Date.h>
 #include <gtest/gtest.h>
+#include <stdlib.h>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -156,6 +157,41 @@ TEST(Date, TimezoneTest)
     // only date part
     EXPECT_EQ(dateLocal.secondsSinceEpoch() - 4 * 3600,
               trantor::Date::fromISOString(dat0).secondsSinceEpoch());
+}
+
+TEST(Date, TimezoneOffsetTest)
+{
+#ifndef _WIN32
+
+    struct TestCase
+    {
+        std::string timezone;
+        std::string local_db_date;
+        std::string utc;
+        int offset;
+    };
+
+    // clang-format off
+    std::vector<TestCase> cases{
+        {"/usr/share/zoneinfo/Europe/Vienna", "2026-03-28 12:00:00", "2026-03-28 11:00:00", 1*60*60},
+        {"/usr/share/zoneinfo/Europe/Vienna", "2026-04-01 12:00:00", "2026-04-01 10:00:00", 2*60*60},
+        {"/usr/share/zoneinfo/Europe/Vienna", "2026-10-25 02:00:00", "2026-10-25 00:00:00", 2*60*60},
+        {"/usr/share/zoneinfo/Europe/Vienna", "2026-10-25 03:00:00", "2026-10-25 02:00:00", 1*60*60}
+    };
+    // clang-format on
+
+    for (auto &t : cases)
+    {
+        EXPECT_TRUE(setenv("TZ", t.timezone.c_str(), 1) != -1);
+        tzset();
+
+        auto local = trantor::Date::fromDbStringLocal(t.local_db_date);
+        auto utc = trantor::Date::fromDbString(t.utc);
+        EXPECT_EQ(local, utc);
+        auto offset = local.timezoneOffsetCurrentDate();
+        EXPECT_EQ(t.offset, offset);
+    }  // for
+#endif
 }
 
 int main(int argc, char **argv)

--- a/trantor/utils/Date.cc
+++ b/trantor/utils/Date.cc
@@ -70,6 +70,19 @@ int64_t Date::timezoneOffset()
     return offset;
 }
 
+int64_t Date::timezoneOffsetCurrentDate() const
+{
+#if defined(__linux__) || defined(__APPLE)
+    struct tm tm;
+    auto seconds = secondsSinceEpoch();
+    localtime_r(&seconds,&tm);
+
+    return tm.tm_gmtoff;
+#else
+    return Date::timezoneOffset();
+#endif
+}
+
 const Date Date::after(double second) const
 {
     return Date(static_cast<int64_t>(microSecondsSinceEpoch_ +
@@ -283,7 +296,7 @@ std::string Date::toDbStringLocal() const
 }
 std::string Date::toDbString() const
 {
-    return after(static_cast<double>(-timezoneOffset())).toDbStringLocal();
+    return after(static_cast<double>(-timezoneOffsetCurrentDate())).toDbStringLocal();
 }
 
 Date Date::fromDbStringLocal(const std::string &datetime)
@@ -358,8 +371,20 @@ Date Date::fromDbStringLocal(const std::string &datetime)
 
 Date Date::fromDbString(const std::string &datetime)
 {
+#if defined(__linux__) || defined(__APPLE)
+    auto d=fromDbStringLocal(datetime);
+
+    struct tm tm;
+    auto seconds = d.secondsSinceEpoch();
+    localtime_r(&seconds,&tm);
+
+    return d.after(static_cast<double>(tm.tm_gmtoff));
+
+#else
+#warning "calculation offset of timezone ignores summer and wintertime"
     return fromDbStringLocal(datetime).after(
         static_cast<double>(timezoneOffset()));
+#endif
 }
 
 static int parseTzOffset(std::string &tz, int tzSign)

--- a/trantor/utils/Date.h
+++ b/trantor/utils/Date.h
@@ -72,7 +72,15 @@ class TRANTOR_EXPORT Date
         return Date::date();
     }
 
+    /**
+     * @brief Difference between local time zone and UTC in seconds
+     * @warning Calculation belongs to 1970-01-01
+     *
+     * @return const Date
+     */
     static int64_t timezoneOffset();
+
+    int64_t timezoneOffsetCurrentDate() const;
 
     /**
      * @brief Return a new Date instance that represents the time after some


### PR DESCRIPTION
The offset calculation uses always 1970-01-01, but it must use the current date. I've added a non static member function. The solution works only fMoor /* Since POSIX.1-2024:  */

