### PR TITLE
Fix overriding stricter configured TLS minimum version

### DIFF
--- a/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
+++ b/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
@@ -196,8 +196,7 @@ struct SSLContext
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
             // Preserve stricter protocol settings from sslConfCmds while
             // enforcing TLS 1.2 as the minimum secure default.
-            const auto minProtoVersion =
-                SSL_CTX_get_min_proto_version(ctx_);
+            const auto minProtoVersion = SSL_CTX_get_min_proto_version(ctx_);
             if (minProtoVersion == 0 || minProtoVersion < TLS1_2_VERSION)
             {
                 SSL_CTX_set_min_proto_version(ctx_, TLS1_2_VERSION);

--- a/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
+++ b/trantor/net/inner/tlsprovider/OpenSSLProvider.cc
@@ -194,7 +194,14 @@ struct SSLContext
         if (useOldTLS == false)
         {
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
-            SSL_CTX_set_min_proto_version(ctx_, TLS1_2_VERSION);
+            // Preserve stricter protocol settings from sslConfCmds while
+            // enforcing TLS 1.2 as the minimum secure default.
+            const auto minProtoVersion =
+                SSL_CTX_get_min_proto_version(ctx_);
+            if (minProtoVersion == 0 || minProtoVersion < TLS1_2_VERSION)
+            {
+                SSL_CTX_set_min_proto_version(ctx_, TLS1_2_VERSION);
+            }
 #else
             const auto opt = SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 |
                              SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;


### PR DESCRIPTION
## Problem

SSL configuration commands are applied before the default minimum TLS
version is set.

When users configure:

    {"MinProtocol", "TLSv1.3"}

the configured value is subsequently overwritten by:

    SSL_CTX_set_min_proto_version(ctx_, TLS1_2_VERSION);

As a result, TLS 1.2 becomes enabled even though the user requested
TLS 1.3 as the minimum version.

## Solution

Read the minimum protocol version after applying SSL configuration
commands. Set TLS 1.2 only when no minimum version was configured or
when the configured version is lower than TLS 1.2.

This preserves the existing secure default while respecting stricter
user configurations such as TLS 1.3.

## Compatibility

The getter is used only for OpenSSL 1.1.1 and later under the existing
version guard. Older OpenSSL versions retain the existing behavior.