### PR TITLE
Fix EPOLLRDHUP/POLLRDHUP mismatch on Linux SPARC/SPARC64

### DIFF
--- a/trantor/net/inner/poller/EpollPoller.cc
+++ b/trantor/net/inner/poller/EpollPoller.cc
@@ -22,6 +22,9 @@
 #include <assert.h>
 #include <strings.h>
 #include <iostream>
+#if (defined(__sparc__) || defined(__sparc))
+#define TRANTOR_RDHUP 0x2800 /* EPOLLRDHUP | POLLRDHUP */
+#endif
 #elif defined _WIN32
 #include "Wepoll.h"
 #include <assert.h>
@@ -38,7 +41,12 @@ namespace trantor
 static_assert(EPOLLIN == POLLIN, "EPOLLIN != POLLIN");
 static_assert(EPOLLPRI == POLLPRI, "EPOLLPRI != POLLPRI");
 static_assert(EPOLLOUT == POLLOUT, "EPOLLOUT != POLLOUT");
+#if (defined(__sparc__) || defined(__sparc))
+static_assert(EPOLLRDHUP & TRANTOR_RDHUP,
+              "EPOLLRDHUP not included in TRANTOR_RDHUP");
+#else
 static_assert(EPOLLRDHUP == POLLRDHUP, "EPOLLRDHUP != POLLRDHUP");
+#endif
 static_assert(EPOLLERR == POLLERR, "EPOLLERR != POLLERR");
 static_assert(EPOLLHUP == POLLHUP, "EPOLLHUP != POLLHUP");
 #endif
@@ -127,7 +135,15 @@ void EpollPoller::fillActiveChannels(int numEvents,
         assert(it != channels_.end());
         assert(it->second == channel);
 #endif
-        channel->setRevents(events_[i].events);
+        int revents = events_[i].events;
+#if defined(__linux__) && (defined(__sparc__) || defined(__sparc))
+        if (revents & EPOLLRDHUP)
+        {
+            revents &= ~EPOLLRDHUP;
+            revents |= POLLRDHUP;
+        }
+#endif
+        channel->setRevents(revents);
         activeChannels->push_back(channel);
     }
     // LOG_TRACE<<"active Channels num:"<<activeChannels->size();
@@ -205,6 +221,13 @@ void EpollPoller::update(int operation, Channel *channel)
     struct epoll_event event;
     memset(&event, 0, sizeof(event));
     event.events = channel->events();
+#if defined(__linux__) && (defined(__sparc__) || defined(__sparc))
+    if (event.events & TRANTOR_RDHUP)
+    {
+        event.events &= ~TRANTOR_RDHUP;
+        event.events |= EPOLLRDHUP;
+    }
+#endif
     event.data.ptr = channel;
     int fd = channel->fd();
     if (::epoll_ctl(epollfd_, operation, fd, &event) < 0)


### PR DESCRIPTION
Fix a build failure reported by Buildroot autobuild for the bootlin-sparc64-glibc configuration:

  EpollPoller.cc:41:26: error: static assertion failed:
  EPOLLRDHUP != POLLRDHUP

On SPARC/SPARC64, EPOLLRDHUP (0x2000) and POLLRDHUP (0x0800) are different bits, breaking the assumption elsewhere in this file that epoll and poll flags are interchangeable.

Introduce a combined RDHUP value for this architecture and translate it before epoll_ctl() and after epoll_wait(), since revents_ is later tested against POLLRDHUP in Channel::handleEvent() — otherwise half-close detection would silently break at runtime.

This patch is inspired by the equivalent fix in lighttpd: https://redmine.lighttpd.net/issues/3251